### PR TITLE
changed links from wayfair-incubator -> wayfair

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.md
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.md
@@ -31,5 +31,5 @@ Please provide the version number where this issue was encountered.
 
 ## Checklist
 
-- [ ] I have read the [contributing guidelines](https://github.com/wayfair-incubator/vsm-ios/blob/main/CONTRIBUTING.md)
+- [ ] I have read the [contributing guidelines](https://github.com/wayfair/vsm-ios/blob/main/CONTRIBUTING.md)
 - [ ] I have verified this does not duplicate an existing issue

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,7 +15,7 @@ Note that by _not_ including a description, you are asking reviewers to do extra
 
 ## Checklist
 
-- [ ] I have read the [contributing guidelines](https://github.com/wayfair-incubator/vsm-ios/blob/main/CONTRIBUTING.md)
+- [ ] I have read the [contributing guidelines](https://github.com/wayfair/vsm-ios/blob/main/CONTRIBUTING.md)
 - [ ] Existing issues have been referenced (where applicable)
 - [ ] I have verified this change is not present in other open pull requests
 - [ ] Functionality is documented

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ any real-time space (eg. Slack, Discord, etc).
 ## Reporting Issues
 
 Before reporting a new issue, please ensure that the issue was not already reported or fixed by searching through our
-[issues list](https://github.com/wayfair-incubator/vsm-ios/issues).
+[issues list](https://github.com/wayfair/vsm-ios/issues).
 
 When creating a new issue, please be sure to include a **title and clear description**, as much relevant information as
 possible, and, if possible, a test case.
@@ -37,7 +37,7 @@ and fix existing bugs. Here is what you can do:
 
 - Help ensure that existing issues follows the recommendations from the _[Reporting Issues](#reporting-issues)_ section,
   providing feedback to the issue's author on what might be missing.
-- Review and update the existing content of our [Wiki](https://github.com/wayfair-incubator/vsm-ios/wiki) with up-to-date
+- Review and update the existing content of our [Wiki](https://github.com/wayfair/vsm-ios/wiki) with up-to-date
   instructions and code samples.
 - Review existing pull requests, and testing patches against real existing applications that use `VSM for iOS`.
 - Write a test, or add a missing test case to an existing test.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-[![Release](https://img.shields.io/github/v/release/wayfair-incubator/vsm-ios?display_name=tag)](CHANGELOG.md)
-[![Lint](https://github.com/wayfair-incubator/vsm-ios/actions/workflows/lint.yml/badge.svg?branch=main)](https://github.com/wayfair-incubator/vsm-ios/actions/workflows/lint.yml)
-[![CI](https://github.com/wayfair-incubator/vsm-ios/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/wayfair-incubator/vsm-ios/actions/workflows/ci.yml)
+[![Release](https://img.shields.io/github/v/release/wayfair/vsm-ios?display_name=tag)](CHANGELOG.md)
+[![Lint](https://github.com/wayfair/vsm-ios/actions/workflows/lint.yml/badge.svg?branch=main)](https://github.com/wayfair/vsm-ios/actions/workflows/lint.yml)
+[![CI](https://github.com/wayfair/vsm-ios/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/wayfair/vsm-ios/actions/workflows/ci.yml)
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.0-4baaaa.svg)](CODE_OF_CONDUCT.md)
 [![Maintainer](https://img.shields.io/badge/Maintainer-Wayfair-7F187F)](https://wayfair.github.io)
 
@@ -16,8 +16,8 @@ VSM stands for View State Model. The View observes and renders the State. Each S
 
 There are several options to help you get started
 
-- Jump into the [Quickstart Guide](https://wayfair-incubator.github.io/vsm-ios/documentation/vsm/quickstartguide)
-- Visit the [VSM Documentation](https://wayfair-incubator.github.io/vsm-ios/documentation/vsm/) for a complete framework reference and links to other learning resources
+- Jump into the [Quickstart Guide](https://wayfair.github.io/vsm-ios/documentation/vsm/quickstartguide)
+- Visit the [VSM Documentation](https://wayfair.github.io/vsm-ios/documentation/vsm/) for a complete framework reference and links to other learning resources
 - Open the [Demo App](Demos/Shopping) to see many different working examples of how to build features using the VSM pattern
 
 ## Project Information


### PR DESCRIPTION
## Description

Since the repo has moved from the [wayfair-incubator](https://github.com/wayfair-incubator/) organization to the [wayfair](https://github.com/wayfair/) organization, some links in the repo that pointed to the old organization were broken and needed to be updated.

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [x] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wayfair-incubator/vsm-ios/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
