### PR TITLE
Protocols, Debugging, and Bug Fixes

### DIFF
--- a/Demos/Shopping/Shopping/ShoppingApp.swift
+++ b/Demos/Shopping/Shopping/ShoppingApp.swift
@@ -14,7 +14,7 @@ struct ShoppingApp: App {
     init() {
         // Uncomment this line to see state changes printed to the console for every StateContainer in the app.
         // NOTE: The line below will produce a compiler warning in DEBUG, and will break any non-DEBUG build.
-        // StateContainer.debug()
+        // StateContainer._debug()
         
         // Configure for UI testing if necessary
         configureUITestBehavior()

--- a/Demos/Shopping/Shopping/Views/Main/MainView.swift
+++ b/Demos/Shopping/Shopping/Views/Main/MainView.swift
@@ -13,7 +13,6 @@ struct MainView: View, ViewStateRendering {
     @ObservedObject private(set) var container: StateContainer<MainViewState>
     
     init(appDependenciesProvider: AsyncResource<MainView.Dependencies>) {
-        //_StateContainerDebugLogger._enableAll = true // Enable this debug-only flag to view all state changes in all `StateContainer`s
         let loaderModel = DependenciesLoaderModel(appDependenciesProvider: appDependenciesProvider)
         container = .init(state: .initialized(loaderModel))
         container.observe(loaderModel.loadDependencies())
@@ -23,6 +22,10 @@ struct MainView: View, ViewStateRendering {
         switch state {
         case .loading, .initialized:
             ProgressView()
+                .onAppear {
+                    // Enable the following debug-only flag to view all state changes in _this_ view
+                    // container._debug()
+                }
         case .loaded(let loadedModel):
             loadedView(loadedModel)
         }

--- a/Demos/Shopping/Shopping/Views/Product/ProductDetailView/ProductDetailView.swift
+++ b/Demos/Shopping/Shopping/Views/Product/ProductDetailView/ProductDetailView.swift
@@ -18,9 +18,6 @@ struct ProductDetailView: View, ViewStateRendering {
         self.dependencies = dependencies
         self.productDetail = productDetail
         container = .init(state: .viewing(AddToCartModel(dependencies: dependencies, productId: productDetail.id)))
-        //    .debug()
-        // Uncomment this line to see state changes printed to the console for this view.
-        // NOTE: The line above will produce a compiler warning in DEBUG, and will break any non-DEBUG build.
     }
     
     var body: some View {        

--- a/Demos/Shopping/Shopping/Views/Profile/ProfileView.swift
+++ b/Demos/Shopping/Shopping/Views/Profile/ProfileView.swift
@@ -38,7 +38,7 @@ struct ProfileView: View, ViewStateRendering {
     func initializedView(loaderModel: ProfileLoaderModeling) -> some View {
         ProgressView()
             .onAppear {
-                container.observe({ await loaderModel.load() })
+                container.observeAsync({ await loaderModel.load() })
             }
             .alert(
                 "Oops!",
@@ -46,7 +46,7 @@ struct ProfileView: View, ViewStateRendering {
                 presenting: loaderModel.error
             ) { error in
                 Button("Retry") {
-                    container.observe({ await loaderModel.load() })
+                    container.observeAsync({ await loaderModel.load() })
                 }
             } message: { error in
                 Text(error)
@@ -61,7 +61,7 @@ struct ProfileView: View, ViewStateRendering {
                     username ?? editingModel.username
                 }, set: { newValue in
                     username = newValue
-                    container.observe({ await editingModel.save(username: newValue)}, debounced: .seconds(0.5))
+                    container.observeAsync({ await editingModel.save(username: newValue)}, debounced: .seconds(0.5))
                 }))
                     .textFieldStyle(.roundedBorder)
                 if case .saving = editingModel.editingState {

--- a/Sources/VSM/StateContainer+Binding.swift
+++ b/Sources/VSM/StateContainer+Binding.swift
@@ -71,7 +71,7 @@ public extension StateContainer {
                 return self.state[keyPath: stateKeyPath]
             },
             set: { newValue in
-                self.observe({ await observedSetter(self.state, newValue) })
+                self.observeAsync({ await observedSetter(self.state, newValue) })
             })
     }
     
@@ -88,7 +88,7 @@ public extension StateContainer {
                 return self.state[keyPath: stateKeyPath]
             },
             set: { newValue in
-                self.observe({ await observedSetter(self.state)(newValue) })
+                self.observeAsync({ await observedSetter(self.state)(newValue) })
             })
     }
 }

--- a/Sources/VSM/StateContainer+Debug.swift
+++ b/Sources/VSM/StateContainer+Debug.swift
@@ -5,16 +5,19 @@
 //  Created by Albert Bori on 5/12/22.
 //
 
-#if DEBUG
-
 import Combine
 import Foundation
 
+#if DEBUG
+
 public extension StateContaining {
     
-    /// Prints all state changes in this `StateContainer`, starting with the current state. ⚠️ Requires DEBUG configuration.
     @available(*, deprecated, message: "This debug statement only compiles in DEBUG schemas.")
     @discardableResult
+    /// Prints all state changes in this `StateContainer`, starting with the current state. ⚠️ Requires DEBUG configuration.
+    /// This can be used multiple times per state container with different options.
+    /// - Parameter options: Controls the type of information you want to see in each log. Defaults to `.default`
+    /// - Returns: Self
     func _debug(options: _StateContainerDebugOptions = .defaults) -> Self {
         if let stateContainer = self as? StateContainer<State> {
             stateContainer.debugLogger.startLogging(for: stateContainer, options: options)
@@ -26,6 +29,7 @@ public extension StateContaining {
 public extension StateContaining where State == Any {
     
     /// Prints all state changes in every `StateContainer` created after this line. ⚠️ Requires DEBUG configuration.
+    /// - Parameter options: Controls the type of information you want to see in each log. Defaults to `.default`
     @available(*, deprecated, message: "This debug statement only compiles in DEBUG schemas.")
     static func _debug(options: _StateContainerDebugOptions = .defaults) {
         StateContainerDebugLogger.defaultLoggingModes = options
@@ -35,6 +39,8 @@ public extension StateContaining where State == Any {
 #endif
 
 extension StateContainer {
+    
+    /// Registers this state container for debug logging if global debug options have been set
     func registerForDebugLogging() {
 #if DEBUG
         if !StateContainerDebugLogger.defaultLoggingModes.isEmpty {
@@ -55,7 +61,7 @@ class StateContainerDebugLogger {
         let description: String
     }
     
-    /// Registers debug logging once per mode per state container (to prevent duplicate logging from multiple calls)
+    /// Registers debug logging once per option-set per state container. Multiple messages per state change are possible, but duplicate messages are not possible.
     func startLogging<State>(for container: StateContainer<State>, options: _StateContainerDebugOptions) {
         guard subscriptions[options] == nil else { return }
         

--- a/Sources/VSM/StateContainer+Debug.swift
+++ b/Sources/VSM/StateContainer+Debug.swift
@@ -10,37 +10,25 @@
 import Combine
 import Foundation
 
-public extension StateContainer {
+public extension StateContaining {
     
     /// Prints all state changes in this `StateContainer`, starting with the current state. ⚠️ Requires DEBUG configuration.
-    @available(*, deprecated, message: "FAILS TO COMPILE in non-DEBUG schemas")
+    @available(*, deprecated, message: "This debug statement only compiles in DEBUG schemas.")
     @discardableResult
-    func debug() -> Self {
-        _StateContainerDebugLogger.register(stateContainer: self)
+    func _debug(options: _StateContainerDebugOptions = .defaults) -> Self {
+        if let stateContainer = self as? StateContainer<State> {
+            stateContainer.debugLogger.startLogging(for: stateContainer, options: options)
+        }
         return self
     }
 }
 
-public extension StateContainer where State == Any {
+public extension StateContaining where State == Any {
     
     /// Prints all state changes in every `StateContainer` created after this line. ⚠️ Requires DEBUG configuration.
-    @available(*, deprecated, message: "FAILS TO COMPILE in non-DEBUG schemas")
-    static func debug() {
-        _StateContainerDebugLogger.isLoggingAllStateContainers = true
-    }
-}
-
-private enum _StateContainerDebugLogger {
-    static var isLoggingAllStateContainers: Bool = false
-    static var cancellables: Set<AnyCancellable> = []
-    
-    static func register<State>(stateContainer: StateContainer<State>) {
-        let stateContainerName = "\(type(of: stateContainer))"
-        stateContainer.$state
-            .sink { changedState in
-                NSLog("\(stateContainerName).state set to: \(changedState)")
-            }
-            .store(in: &cancellables)
+    @available(*, deprecated, message: "This debug statement only compiles in DEBUG schemas.")
+    static func _debug(options: _StateContainerDebugOptions = .defaults) {
+        StateContainerDebugLogger.defaultLoggingModes = options
     }
 }
 
@@ -49,9 +37,105 @@ private enum _StateContainerDebugLogger {
 extension StateContainer {
     func registerForDebugLogging() {
 #if DEBUG
-        if _StateContainerDebugLogger.isLoggingAllStateContainers {
-            _StateContainerDebugLogger.register(stateContainer: self)
+        if !StateContainerDebugLogger.defaultLoggingModes.isEmpty {
+            debugLogger.startLogging(for: self, options: StateContainerDebugLogger.defaultLoggingModes)
         }
 #endif
+    }
+}
+
+/// Manages debug logging for a state container
+class StateContainerDebugLogger {
+    static var defaultLoggingModes: _StateContainerDebugOptions = []
+    private lazy var subscriptions: [_StateContainerDebugOptions: AnyCancellable] = [:]
+        
+    private struct Event<State> {
+        let name: String
+        let state: State
+        let description: String
+    }
+    
+    /// Registers debug logging once per mode per state container (to prevent duplicate logging from multiple calls)
+    func startLogging<State>(for container: StateContainer<State>, options: _StateContainerDebugOptions) {
+        guard subscriptions[options] == nil else { return }
+        
+        let memoryAddress = "[\(Unmanaged.passUnretained(container).toOpaque())]"
+        let containerType = "\(type(of: container))"
+        var publisher: AnyPublisher<Event, Never> = Empty<Event<State>, Never>().eraseToAnyPublisher()
+        
+        if options.contains(.willSet) {
+            publisher = publisher
+                .merge(with: container.$state
+                    .map({ .init(name: "willSet", state: $0, description: "\($0)") }))
+                .eraseToAnyPublisher()
+        }
+        if options.contains(.didSet) {
+            publisher = publisher
+                .merge(with: container.publisher
+                    .map({ .init(name: "didSet", state: $0, description: "\($0)") }))
+                .eraseToAnyPublisher()
+        }
+        
+        subscriptions[options] = publisher
+            .sink { event in
+                var logParts: [String] = []
+                if options.contains(.memory) {
+                    logParts.append(memoryAddress)
+                }
+                if options.contains(.container) {
+                    logParts.append(containerType)
+                }
+                if options.contains(.event) {
+                    logParts.append(event.name)
+                }
+                if options.contains(.enumLabel) {
+                    logParts.append(_StateContainerUtils.getEnumName(event.state))
+                } else {
+                    logParts.append(event.description)
+                }
+                if options.contains(.print) {
+                    print(logParts.joined(separator: " "))
+                }
+                if options.contains(.nsLog) {
+                    NSLog(logParts.joined(separator: " "))
+                }
+            }
+    }
+}
+
+public struct _StateContainerDebugOptions: OptionSet, Hashable {
+    public var rawValue: Int
+    
+    public init(rawValue: Int) {
+        self.rawValue = rawValue
+    }
+    
+    /// Logs when the state will be set
+    public static let willSet   = _StateContainerDebugOptions(rawValue: 1 << 0)
+    /// Logs when the state has been set
+    public static let didSet    = _StateContainerDebugOptions(rawValue: 1 << 1)
+    /// Use the print function for emitting the log to the console
+    public static let print     = _StateContainerDebugOptions(rawValue: 1 << 2)
+    /// Use the NSLog function for emitting the log to the console
+    public static let nsLog     = _StateContainerDebugOptions(rawValue: 1 << 3)
+    /// Includes the memory address of the state container
+    public static let memory    = _StateContainerDebugOptions(rawValue: 1 << 4)
+    /// Includes the state container name
+    public static let container = _StateContainerDebugOptions(rawValue: 1 << 5)
+    /// Includes the event name
+    public static let event     = _StateContainerDebugOptions(rawValue: 1 << 6)
+    /// Prints only the name of the enum value
+    public static let enumLabel = _StateContainerDebugOptions(rawValue: 1 << 7)
+    
+    /// `[.didSet, .print]`
+    public static let defaults: Self = [.didSet, .print, .memory, .container, .event]
+    public static let enumDefaults: Self = [.didSet, .print, .memory, .container, .event, .enumLabel]
+    public static let conciseEnum: Self = [.didSet, .print, .enumLabel]
+}
+
+public enum _StateContainerUtils {
+    public static func getEnumName(_ subject: Any) -> String {
+        let mirror = Mirror(reflecting: subject)
+        return mirror.children.first?.label ?? "\(subject)"
     }
 }

--- a/Sources/VSM/StateContainer.swift
+++ b/Sources/VSM/StateContainer.swift
@@ -3,29 +3,61 @@ import Foundation
 
 /// Assists views by managing the current view state.
 /// Observes the output of actions called by the view.
-final public class StateContainer<State>: ObservableObject {
+final public class StateContainer<State>: ObservableObject, StateContaining {
     
-    @Published public private(set) var state: State
-    private var cancellable: AnyCancellable?
-    private var asyncTask: Task<Void, Error>?
+    /// The current state, managed by this container.
+    ///
+    /// This value is always updated on the main thread.
+    @Published public private(set) var state: State {
+        didSet {
+            stateDidChangeSubject.value = state
+        }
+    }
+    
+    /// Publishes the State on `didSet` (main thread). For a `willSet` publisher, use the `$state` projected value.
+    public lazy var publisher: AnyPublisher<State, Never> = {
+        stateDidChangeSubject.eraseToAnyPublisher()
+    }()
+    
+    /// Used for debug logging. Inert in non-DEBUG schemas.
+    lazy var debugLogger: StateContainerDebugLogger = StateContainerDebugLogger()
+    
+    private var stateSubscription: AnyCancellable?
+    private var stateTask: Task<Void, Error>?
+    private var stateDidChangeSubject: CurrentValueSubject<State, Never>
     
     // Debounce Properties
     private var debounceSubscriptionQueue: DispatchQueue = DispatchQueue(label: #function, qos: .userInitiated)
-    private var debounceCancellables: [AnyHashable: AnyCancellable] = [:]
+    private var debounceSubscriptions: [AnyHashable: AnyCancellable] = [:]
     private var debouncePublisher: PassthroughSubject<DebounceableAction, Never> = .init()
     private var defaultDebounceId: UUID = .init() // Prevents accidental debounce collisions with custom identifiers
     
     public init(state: State) {
         self.state = state
+        self.stateDidChangeSubject = .init(state)
         registerForDebugLogging()
+    }
+    
+    /// This function exists to ensure that state is set synchronously if on main, or asynchronously if not on main.
+    /// This prevents accidental frame-draws early in the view lifecycle in both SwiftUI and UIKit.
+    /// Detail: `.receive(on: DispatchQueue.main)` queues asynchronously, always causing a thread-hop even if the subscription and send were performed on the main thread. TBD whether a runtime optimized Tasks (MainActor) would have the same problem
+    /// In a future iOS 15+ version, this class will be converted fully to the `MainActor` paradigm
+    private func setStateOnMainThread(to newState: State) {
+        if Thread.isMainThread {
+            state = newState
+        } else {
+            DispatchQueue.main.async { [weak self] in
+                self?.state = newState
+            }
+        }
     }
     
     /// Cancels any Combine `Subscriber`s that are being observed or Swift Concurrency `Task`s that are being run
     func cancelRunningObservations() {
-        cancellable?.cancel()
-        cancellable = nil
-        asyncTask?.cancel()
-        asyncTask = nil
+        stateSubscription?.cancel()
+        stateSubscription = nil
+        stateTask?.cancel()
+        stateTask = nil
     }
     
     deinit {
@@ -37,21 +69,20 @@ final public class StateContainer<State>: ObservableObject {
 
 public extension StateContainer {
     /// Observes the state publisher emitted as a result of invoking some action
-    func observe(_ stateChangePublisher: AnyPublisher<State, Never>) {
+    func observe(_ statePublisher: AnyPublisher<State, Never>) {
         cancelRunningObservations()
-        cancellable = stateChangePublisher
-            .receive(on: DispatchQueue.main)
+        stateSubscription = statePublisher
             .sink { [weak self] newState in
-                self?.state = newState
+                self?.setStateOnMainThread(to: newState)
             }
     }
     
     /// Observes the state emitted as a result of invoking some asynchronous action
-    func observe(_ awaitState: @escaping () async -> State) {
+    func observeAsync(_ nextState: @escaping () async -> State) {
         cancelRunningObservations()
         // A weak-self declaration is required on the `Task` closure to break an unexpected strong self retention, despite not directly invoking self ¯\_(ツ)_/¯
-        asyncTask = Task(priority: .userInitiated) { [weak self] in
-            let newState = await awaitState()
+        stateTask = Task(priority: .userInitiated) { [weak self] in
+            let newState = await nextState()
             guard !Task.isCancelled else { return }
             // GCD is used here instead of `MainActor` to avoid back-ported Swift Concurrency crashes relating to `MainActor` usage
             // In a future iOS 15+ version, this class will be converted fully to the `MainActor` paradigm
@@ -62,11 +93,11 @@ public extension StateContainer {
     }
     
     /// Observes the states emitted as a result of invoking some asynchronous action that returns an asynchronous sequence
-    func observe<SomeAsyncSequence: AsyncSequence>(_ awaitStateSequence: @escaping () async -> SomeAsyncSequence) where SomeAsyncSequence.Element == State {
+    func observeAsync<SomeAsyncSequence: AsyncSequence>(_ stateSequence: @escaping () async -> SomeAsyncSequence) where SomeAsyncSequence.Element == State {
         cancelRunningObservations()
         // A weak-self declaration is required on the `Task` closure to break an unexpected strong self retention, despite not directly invoking self ¯\_(ツ)_/¯
-        asyncTask = Task(priority: .userInitiated) { [weak self] in
-            for try await newState in await awaitStateSequence() {
+        stateTask = Task(priority: .userInitiated) { [weak self] in
+            for try await newState in await stateSequence() {
                 guard !Task.isCancelled else { break }
                 // GCD is used here instead of `MainActor` to avoid back-ported Swift Concurrency crashes relating to `MainActor` usage
                 // In a future iOS 15+ version, this class will be converted fully to the `MainActor` paradigm
@@ -78,16 +109,9 @@ public extension StateContainer {
     }
     
     /// Observes the state emitted as a result of invoking some synchronous action
-    func observe(_ nextState: @autoclosure @escaping () -> State) {
+    func observe(_ nextState: State) {
         cancelRunningObservations()
-        let newState = nextState()
-        if Thread.isMainThread {
-            state = newState
-        } else {
-            DispatchQueue.main.async { [weak self] in
-                self?.state = newState
-            }
-        }
+        setStateOnMainThread(to: nextState)
     }
 }
 
@@ -103,8 +127,8 @@ public extension StateContainer {
     
     private func debounce(action: DebounceableAction) {
         debounceSubscriptionQueue.sync {
-            if debounceCancellables[action.identifier] == nil {
-                debounceCancellables[action.identifier] = debouncePublisher
+            if debounceSubscriptions[action.identifier] == nil {
+                debounceSubscriptions[action.identifier] = debouncePublisher
                     .filter({ $0.identifier == action.identifier })
                     .debounce(for: action.dueTime, scheduler: DispatchQueue.main)
                     .sink {
@@ -114,146 +138,76 @@ public extension StateContainer {
         }
         debouncePublisher.send(action)
     }
-        
-    /// Debounces the action calls by `dueTime`, then observes the `State` publisher emitted as a result of invoking the action.
-    /// Prevents actions from being excessively called when bound to noisy UI events.
-    /// Action calls are automatically grouped by call location. Use `observe(_:debounced:identifier:)` if you need custom debounce grouping.
-    /// - Parameters:
-    ///   - stateChangePublisherAction: The action to be debounced before invoking
-    ///   - dueTime: The amount of time required to pass before invoking the most recent action
-    func observe(
-        _ stateChangePublisherAction: @escaping @autoclosure () -> AnyPublisher<State, Never>,
-        debounced dueTime: DispatchQueue.SchedulerTimeType.Stride,
-        file: String = #file,
-        line: UInt = #line
-    ) {
-        let debounceGroupId = DebounceIdentifier(defaultId: defaultDebounceId, file: file, line: line)
-        observe(stateChangePublisherAction(), debounced: dueTime, identifier: debounceGroupId)
-    }
     
     /// Debounces the action calls by `dueTime`, then observes the `State` publisher emitted as a result of invoking the action.
     /// Prevents actions from being excessively called when bound to noisy UI events.
     /// Action calls are grouped by the provided `identifier`.
     /// - Parameters:
-    ///   - stateChangePublisherAction: The action to be debounced before invoking
+    ///   - statePublisher: The action to be debounced before invoking
     ///   - dueTime: The amount of time required to pass before invoking the most recent action
     ///   - identifier: The identifier for grouping actions for debouncing
     func observe(
-        _ stateChangePublisherAction: @escaping @autoclosure () -> AnyPublisher<State, Never>,
+        _ statePublisher: @escaping @autoclosure () -> AnyPublisher<State, Never>,
         debounced dueTime: DispatchQueue.SchedulerTimeType.Stride,
         identifier: AnyHashable
     ) {
         let debounceableAction = DebounceableAction(identifier: identifier, dueTime: dueTime) { [weak self] in
-            self?.observe(stateChangePublisherAction().eraseToAnyPublisher())
+            self?.observe(statePublisher().eraseToAnyPublisher())
         }
         debounce(action: debounceableAction)
     }
     
     /// Debounces the action calls by `dueTime`, then asynchronously observes the `State` returned as a result of invoking the action.
     /// Prevents actions from being excessively called when bound to noisy UI events.
-    /// Action calls are automatically grouped by call location. Use `observe(_:debounced:identifier:)` if you need custom debounce grouping.
-    /// - Parameters:
-    ///   - stateChangeAsyncAction: The action to be debounced before invoking
-    ///   - dueTime: The amount of time required to pass before invoking the most recent action
-    func observe(
-        _ stateChangeAsyncAction: @escaping () async -> State,
-        debounced dueTime: DispatchQueue.SchedulerTimeType.Stride,
-        file: String = #file,
-        line: UInt = #line
-    ) {
-        let debounceGroupId = DebounceIdentifier(defaultId: defaultDebounceId, file: file, line: line)
-        observe(stateChangeAsyncAction, debounced: dueTime, identifier: debounceGroupId)
-    }
-    
-    /// Debounces the action calls by `dueTime`, then asynchronously observes the `State` returned as a result of invoking the action.
-    /// Prevents actions from being excessively called when bound to noisy UI events.
     /// Action calls are grouped by the provided `identifier`.
     /// - Parameters:
-    ///   - stateChangeAsyncAction: The action to be debounced before invoking
+    ///   - nextState: The action to be debounced before invoking
     ///   - dueTime: The amount of time required to pass before invoking the most recent action
     ///   - identifier: The identifier for grouping actions for debouncing
-    func observe(
-        _ stateChangeAsyncAction: @escaping () async -> State,
+    func observeAsync(
+        _ nextState: @escaping () async -> State,
         debounced dueTime: DispatchQueue.SchedulerTimeType.Stride,
         identifier: AnyHashable
     ) {
         let debounceableAction = DebounceableAction(identifier: identifier, dueTime: dueTime) { [weak self] in
-            self?.observe({ await stateChangeAsyncAction() })
+            self?.observeAsync({ await nextState() })
         }
         debounce(action: debounceableAction)
     }
     
     /// Debounces the action calls by `dueTime`, then observes the async sequence of `State`s returned as a result of invoking the action.
     /// Prevents actions from being excessively called when bound to noisy UI events.
-    /// Action calls are automatically grouped by call location. Use `observe(_:debounced:identifier:)` if you need custom debounce grouping.
-    /// - Parameters:
-    ///   - stateChangeAsyncSequenceAction: The action to be debounced before invoking
-    ///   - dueTime: The amount of time required to pass before invoking the most recent action
-    func observe<SomeAsyncSequence: AsyncSequence>(
-        _ stateChangeAsyncSequenceAction: @escaping () async -> SomeAsyncSequence,
-        debounced dueTime: DispatchQueue.SchedulerTimeType.Stride,
-        file: String = #file,
-        line: UInt = #line
-    ) where SomeAsyncSequence.Element == State {
-        let debounceGroupId = DebounceIdentifier(defaultId: defaultDebounceId, file: file, line: line)
-        observe(stateChangeAsyncSequenceAction, debounced: dueTime, identifier: debounceGroupId)
-    }
-    
-    /// Debounces the action calls by `dueTime`, then observes the async sequence of `State`s returned as a result of invoking the action.
-    /// Prevents actions from being excessively called when bound to noisy UI events.
     /// Action calls are grouped by the provided `identifier`.
     /// - Parameters:
-    ///   - stateChangeAsyncSequenceAction: The action to be debounced before invoking
+    ///   - stateSequence: The action to be debounced before invoking
     ///   - dueTime: The amount of time required to pass before invoking the most recent action
     ///   - identifier: The identifier for grouping actions for debouncing
-    func observe<SomeAsyncSequence: AsyncSequence>(
-        _ stateChangeAsyncSequenceAction: @escaping () async -> SomeAsyncSequence,
+    func observeAsync<SomeAsyncSequence: AsyncSequence>(
+        _ stateSequence: @escaping () async -> SomeAsyncSequence,
         debounced dueTime: DispatchQueue.SchedulerTimeType.Stride,
         identifier: AnyHashable
     ) where SomeAsyncSequence.Element == State {
         let debounceableAction = DebounceableAction(identifier: identifier, dueTime: dueTime) { [weak self] in
-            self?.observe({ await stateChangeAsyncSequenceAction() })
+            self?.observeAsync({ await stateSequence() })
         }
         debounce(action: debounceableAction)
     }
     
     /// Debounces the action calls by `dueTime`, then observes the `State` returned as a result of invoking the action.
     /// Prevents actions from being excessively called when bound to noisy UI events.
-    /// Action calls are automatically grouped by call location. Use `observe(_:debounced:identifier:)` if you need custom debounce grouping.
-    /// - Parameters:
-    ///   - stateChangeAction: The action to be debounced before invoking
-    ///   - dueTime: The amount of time required to pass before invoking the most recent action
-    func observe(
-        _ stateChangeAction: @escaping @autoclosure () -> State,
-        debounced dueTime: DispatchQueue.SchedulerTimeType.Stride,
-        file: String = #file,
-        line: UInt = #line
-    ) {
-        let debounceGroupId = DebounceIdentifier(defaultId: defaultDebounceId, file: file, line: line)
-        observe(stateChangeAction(), debounced: dueTime, identifier: debounceGroupId)
-    }
-    
-    /// Debounces the action calls by `dueTime`, then observes the `State` returned as a result of invoking the action.
-    /// Prevents actions from being excessively called when bound to noisy UI events.
     /// Action calls are grouped by the provided `identifier`.
     /// - Parameters:
-    ///   - stateChangeAction: The action to be debounced before invoking
+    ///   - nextState: The action to be debounced before invoking
     ///   - dueTime: The amount of time required to pass before invoking the most recent action
     ///   - identifier: The identifier for grouping actions for debouncing
     func observe(
-        _ stateChangeAction: @escaping @autoclosure () -> State,
+        _ nextState: @escaping @autoclosure () -> State,
         debounced dueTime: DispatchQueue.SchedulerTimeType.Stride,
         identifier: AnyHashable
     ) {
         let debounceableAction = DebounceableAction(identifier: identifier, dueTime: dueTime) { [weak self] in
-            self?.observe(stateChangeAction())
+            self?.observe(nextState())
         }
         debounce(action: debounceableAction)
     }
-}
-
-private struct DebounceIdentifier: Hashable {
-    let defaultId: UUID
-    let file: String
-    let line: UInt
 }

--- a/Sources/VSM/StateContainer/StateBinding.swift
+++ b/Sources/VSM/StateContainer/StateBinding.swift
@@ -1,0 +1,61 @@
+//
+//  StateBinding.swift
+//
+//
+//  Created by Albert Bori on 1/26/23.
+//
+
+#if canImport(SwiftUI)
+import Combine
+import Foundation
+import SwiftUI
+
+public protocol StateBinding<State> {
+    associatedtype State
+    
+    /// Creates a unidirectional, auto-observing `Binding<Value>` for the `ViewState` using a `KeyPath` and a basic closure.
+    /// **Not intended for use when`ViewState` is an enum.**
+    /// - Parameters:
+    ///   - stateKeyPath: `KeyPath` for a `Value` of the `ViewState`
+    ///   - observedSetter: Converts the new `Value` to a new `ViewState`, which is automatically observed
+    /// - Returns: A `Binding<Value>` for use in SwiftUI controls
+    func bind<Value>(_ stateKeyPath: KeyPath<State, Value>, to observedSetter: @escaping (State, Value) -> State) -> Binding<Value>
+    
+    /// Creates a unidirectional, auto-observing `Binding<Value>` for the `ViewState` using a `KeyPath` and a *method signature*
+    /// **This doesn't work when`ViewState` is an enum**
+    /// Example usage: `bind(\.someModelProperty, to: ViewState.someModelMethod)`
+    /// - Parameters:
+    ///   - stateKeyPath: `KeyPath` for a `Value` of the `ViewState`
+    ///   - observedSetter: A **method signature** which converts the new `Value` to a new `ViewState` and is automatically observed
+    /// - Returns: A `Binding<Value>` for use in SwiftUI controls
+    func bind<Value>(_ stateKeyPath: KeyPath<State, Value>, to observedSetter: @escaping (State) -> (Value) -> State) -> Binding<Value>
+    
+    /// Creates a unidirectional, auto-observing `Binding<Value>` for the `ViewState` using a `KeyPath` and a basic closure.
+    /// **Not intended for use when`ViewState` is an enum.**
+    /// - Parameters:
+    ///   - stateKeyPath: `KeyPath` for a `Value` of the `ViewState`
+    ///   - observedSetter: Converts the new `Value` to a new `ViewState`, which is automatically observed
+    /// - Returns: A `Binding<Value>` for use in SwiftUI controls
+    func bind<Value>(_ stateKeyPath: KeyPath<State, Value>, to observedSetter: @escaping (State, Value) -> AnyPublisher<State, Never>) -> Binding<Value>
+    
+    /// Creates a unidirectional, auto-observing `Binding<Value>` for the `ViewState` using a `KeyPath` and a *method signature*
+    /// **Not intended for use when`ViewState` is an enum.**
+    /// Example usage: `bind(\.someModelProperty, to: ViewState.someModelMethod)`
+    /// - Parameters:
+    ///   - stateKeyPath: `KeyPath` for a `Value` of the `ViewState`
+    ///   - observedSetter: A **method signature** which converts the new `Value` to a new `ViewState` and is automatically observed
+    /// - Returns: A `Binding<Value>` for use in SwiftUI controls
+    func bind<Value>(_ stateKeyPath: KeyPath<State, Value>, to observedSetter: @escaping (State) -> (Value) -> AnyPublisher<State, Never>) -> Binding<Value>
+}
+
+struct HashedIdentifier: Hashable {
+    let uniqueValues: [AnyHashable]
+    
+    /// Prevents accidental key collisions between auto-generated identifiers and manually generated identifiers
+    private static var uniqueKey: AnyHashable = UUID()
+    
+    init(_ values: AnyHashable ...) {
+        uniqueValues = [Self.uniqueKey] + values
+    }
+}
+#endif

--- a/Sources/VSM/StateContainer/StateBinding.swift
+++ b/Sources/VSM/StateContainer/StateBinding.swift
@@ -52,7 +52,7 @@ struct HashedIdentifier: Hashable {
     let uniqueValues: [AnyHashable]
     
     /// Prevents accidental key collisions between auto-generated identifiers and manually generated identifiers
-    private static var uniqueKey: AnyHashable = UUID()
+    private static let uniqueKey: AnyHashable = UUID()
     
     init(_ values: AnyHashable ...) {
         uniqueValues = [Self.uniqueKey] + values

--- a/Sources/VSM/StateContainer/StateContaining.swift
+++ b/Sources/VSM/StateContainer/StateContaining.swift
@@ -1,0 +1,22 @@
+//
+//  StateContaining.swift
+//
+//
+//  Created by Albert Bori on 1/23/23.
+//
+
+import Combine
+
+#if canImport(SwiftUI)
+
+import SwiftUI
+
+/// Combines commonly used state management protocols into a single protocol
+public protocol StateContaining<State>: StateObserving, StatePublishing, StateBinding { }
+
+#else
+
+/// Combines commonly used state management protocols into a single protocol
+public protocol StateContaining<State>: StateObserving, StatePublishing { }
+
+#endif

--- a/Sources/VSM/StateContainer/StateObserving.swift
+++ b/Sources/VSM/StateContainer/StateObserving.swift
@@ -1,0 +1,143 @@
+//
+//  StateObserving.swift
+//
+//
+//  Created by Albert Bori on 1/26/23.
+//
+
+import Combine
+import Foundation
+
+/// Provides functions for observing an action for potentially new states
+public protocol StateObserving<State> {
+    associatedtype State
+    
+    /// Observes the state publisher emitted as a result of invoking some action
+    func observe(_ statePublisher: AnyPublisher<State, Never>)
+
+    /// Observes the state emitted as a result of invoking some synchronous action
+    func observe(_ nextState: State)
+    
+    /// Observes the state emitted as a result of invoking some asynchronous action
+    func observeAsync(_ nextState: @escaping () async -> State)
+    
+    /// Observes the states emitted as a result of invoking some asynchronous action that returns an asynchronous sequence
+    func observeAsync<StateSequence: AsyncSequence>(_ stateSequence: @escaping () async -> StateSequence) where StateSequence.Element == State
+    
+    // MARK: - Debounce
+    
+    /// Debounces the action calls by `dueTime`, then observes the `State` publisher emitted as a result of invoking the action.
+    /// Prevents actions from being excessively called when bound to noisy UI events.
+    /// Action calls are grouped by the provided `identifier`.
+    /// - Parameters:
+    ///   - statePublisher: The action to be debounced before invoking
+    ///   - dueTime: The amount of time required to pass before invoking the most recent action
+    ///   - identifier: The identifier for grouping actions for debouncing
+    func observe(
+        _ statePublisher: @escaping @autoclosure () ->  AnyPublisher<State, Never>,
+        debounced dueTime: DispatchQueue.SchedulerTimeType.Stride,
+        identifier: AnyHashable
+    )
+    
+    /// Debounces the action calls by `dueTime`, then observes the `State` returned as a result of invoking the action.
+    /// Prevents actions from being excessively called when bound to noisy UI events.
+    /// Action calls are grouped by the provided `identifier`.
+    /// - Parameters:
+    ///   - nextState: The action to be debounced before invoking
+    ///   - dueTime: The amount of time required to pass before invoking the most recent action
+    ///   - identifier: The identifier for grouping actions for debouncing
+    func observe(
+        _ nextState: @escaping @autoclosure () -> State,
+        debounced dueTime: DispatchQueue.SchedulerTimeType.Stride,
+        identifier: AnyHashable
+    )
+    
+    /// Debounces the action calls by `dueTime`, then asynchronously observes the `State` returned as a result of invoking the action.
+    /// Prevents actions from being excessively called when bound to noisy UI events.
+    /// Action calls are grouped by the provided `identifier`.
+    /// - Parameters:
+    ///   - nextState: The action to be debounced before invoking
+    ///   - dueTime: The amount of time required to pass before invoking the most recent action
+    ///   - identifier: The identifier for grouping actions for debouncing
+    func observeAsync(
+        _ nextState: @escaping () async -> State, // "async" parameter name solves runtime closure disambiguation bug
+        debounced dueTime: DispatchQueue.SchedulerTimeType.Stride,
+        identifier: AnyHashable
+    )
+    
+    /// Debounces the action calls by `dueTime`, then observes the async sequence of `State`s returned as a result of invoking the action.
+    /// Prevents actions from being excessively called when bound to noisy UI events.
+    /// Action calls are grouped by the provided `identifier`.
+    /// - Parameters:
+    ///   - stateSequence: The action to be debounced before invoking
+    ///   - dueTime: The amount of time required to pass before invoking the most recent action
+    ///   - identifier: The identifier for grouping actions for debouncing
+    func observeAsync<SomeAsyncSequence: AsyncSequence>(
+        _ stateSequence: @escaping () async -> SomeAsyncSequence,
+        debounced dueTime: DispatchQueue.SchedulerTimeType.Stride,
+        identifier: AnyHashable
+    ) where SomeAsyncSequence.Element == State
+}
+
+public extension StateObserving {
+        
+    /// Debounces the action calls by `dueTime`, then observes the `State` publisher emitted as a result of invoking the action.
+    /// Prevents actions from being excessively called when bound to noisy UI events.
+    /// Action calls are automatically grouped by call location. Use `observe(_:debounced:identifier:)` if you need custom debounce grouping.
+    /// - Parameters:
+    ///   - statePublisher: The action to be debounced before invoking
+    ///   - dueTime: The amount of time required to pass before invoking the most recent action
+    func observe(
+        _ statePublisher: @escaping @autoclosure () -> AnyPublisher<State, Never>,
+        debounced dueTime: DispatchQueue.SchedulerTimeType.Stride,
+        file: String = #file,
+        line: UInt = #line
+    ) {
+        observe(statePublisher(), debounced: dueTime, identifier: HashedIdentifier(file, line))
+    }
+    
+    /// Debounces the action calls by `dueTime`, then observes the `State` returned as a result of invoking the action.
+    /// Prevents actions from being excessively called when bound to noisy UI events.
+    /// Action calls are automatically grouped by call location. Use `observe(_:debounced:identifier:)` if you need custom debounce grouping.
+    /// - Parameters:
+    ///   - nextState: The action to be debounced before invoking
+    ///   - dueTime: The amount of time required to pass before invoking the most recent action
+    func observe(
+        _ nextState: @escaping () -> State,
+        debounced dueTime: DispatchQueue.SchedulerTimeType.Stride,
+        file: String = #file,
+        line: UInt = #line
+    ) {
+        observe(nextState(), debounced: dueTime, identifier: HashedIdentifier(file, line))
+    }
+    
+    /// Debounces the action calls by `dueTime`, then asynchronously observes the `State` returned as a result of invoking the action.
+    /// Prevents actions from being excessively called when bound to noisy UI events.
+    /// Action calls are automatically grouped by call location. Use `observe(_:debounced:identifier:)` if you need custom debounce grouping.
+    /// - Parameters:
+    ///   - nextState: The action to be debounced before invoking
+    ///   - dueTime: The amount of time required to pass before invoking the most recent action
+    func observeAsync(
+        _ nextState: @escaping () async -> State, // "async" parameter name solves runtime closure disambiguation bug
+        debounced dueTime: DispatchQueue.SchedulerTimeType.Stride,
+        file: String = #file,
+        line: UInt = #line
+    ) {
+        observeAsync(nextState, debounced: dueTime, identifier: HashedIdentifier(file, line))
+    }
+    
+    /// Debounces the action calls by `dueTime`, then observes the async sequence of `State`s returned as a result of invoking the action.
+    /// Prevents actions from being excessively called when bound to noisy UI events.
+    /// Action calls are automatically grouped by call location. Use `observe(_:debounced:identifier:)` if you need custom debounce grouping.
+    /// - Parameters:
+    ///   - stateSequence: The action to be debounced before invoking
+    ///   - dueTime: The amount of time required to pass before invoking the most recent action
+    func observeAsync<SomeAsyncSequence: AsyncSequence>(
+        _ stateSequence: @escaping () async -> SomeAsyncSequence,
+        debounced dueTime: DispatchQueue.SchedulerTimeType.Stride,
+        file: String = #file,
+        line: UInt = #line
+    ) where SomeAsyncSequence.Element == State {
+        observeAsync(stateSequence, debounced: dueTime, identifier: HashedIdentifier(file, line))
+    }
+}

--- a/Sources/VSM/StateContainer/StatePublishing.swift
+++ b/Sources/VSM/StateContainer/StatePublishing.swift
@@ -1,0 +1,16 @@
+//
+//  StatePublishing.swift
+//
+//
+//  Created by Albert Bori on 1/26/23.
+//
+
+import Combine
+
+/// Provides a state publisher for observation
+public protocol StatePublishing<State> {
+    associatedtype State
+    
+    /// Publishes the State changes on the main thread
+    var publisher: AnyPublisher<State, Never> { get }
+}

--- a/Sources/VSM/ViewStateRendering.swift
+++ b/Sources/VSM/ViewStateRendering.swift
@@ -9,7 +9,7 @@ import Combine
 /// SwiftUI Example
 /// ```swift
 /// struct UserProfileView: View, ViewStateRendering {
-///     var container = StateContainer<UserProfileViewState>(state: .initialized(LoaderModel()))
+///     @StateObject var container = StateContainer<UserProfileViewState>(state: .initialized(LoaderModel()))
 ///     var body: some View {
 ///         switch state {
 ///         case .initialized, .loading:
@@ -102,20 +102,20 @@ public extension ViewStateRendering {
 
     /// Convenience accessor for the `StateContainer`'s `observe` function.
     /// Observes the state emitted as a result of invoking some asynchronous action
-    func observe(_ awaitState: @escaping () async -> ViewState) {
-        container.observe(awaitState)
+    func observeAsync(_ awaitState: @escaping () async -> ViewState) {
+        container.observeAsync(awaitState)
     }
     
     /// Convenience accessor for the `StateContainer`'s `observe` function.
     /// Observes the states emitted as a result of invoking some asynchronous action that returns an asynchronous sequence
-    func observe<StateSequence: AsyncSequence>(_ awaitStateSequence: @escaping () async -> StateSequence) where StateSequence.Element == ViewState {
-        container.observe(awaitStateSequence)
+    func observeAsync<StateSequence: AsyncSequence>(_ awaitStateSequence: @escaping () async -> StateSequence) where StateSequence.Element == ViewState {
+        container.observeAsync(awaitStateSequence)
     }
 
     /// Convenience accessor for the `StateContainer`'s `observe` function.
     /// Observes the state emitted as a result of invoking some synchronous action
     func observe(_ nextState: @autoclosure @escaping () -> ViewState) {
-        container.observe(nextState)
+        container.observe(nextState())
     }
 }
 
@@ -245,73 +245,73 @@ public extension ViewStateRendering {
     /// - Parameters:
     ///   - stateChangeAsyncAction: The action to be debounced before invoking
     ///   - dueTime: The amount of time required to pass before invoking the most recent action
-    func observe(
+    func observeAsync(
         _ stateChangeAsyncAction: @escaping () async -> ViewState,
         debounced dueTime: DispatchQueue.SchedulerTimeType.Stride,
         file: String = #file,
         line: UInt = #line
     ) {
-        container.observe(stateChangeAsyncAction, debounced: dueTime, file: file, line: line)
+        container.observeAsync(stateChangeAsyncAction, debounced: dueTime, file: file, line: line)
     }
     
     /// Debounces the action calls by `dueTime`, then asynchronously observes the `State` returned as a result of invoking the action.
     /// Prevents actions from being excessively called when bound to noisy UI events.
     /// Action calls are grouped by the provided `identifier`.
     /// - Parameters:
-    ///   - stateChangeAsyncAction: The action to be debounced before invoking
+    ///   - nextState: The action to be debounced before invoking
     ///   - dueTime: The amount of time required to pass before invoking the most recent action
     ///   - identifier: The identifier for grouping actions for debouncing
-    func observe(
-        _ stateChangeAsyncAction: @escaping () async -> ViewState,
+    func observeAsync(
+        _ nextState: @escaping () async -> ViewState,
         debounced dueTime: DispatchQueue.SchedulerTimeType.Stride,
         identifier: AnyHashable
     ) {
-        container.observe(stateChangeAsyncAction, debounced: dueTime, identifier: identifier)
+        container.observeAsync(nextState, debounced: dueTime, identifier: identifier)
     }
     
     /// Debounces the action calls by `dueTime`, then observes the async sequence of `State`s returned as a result of invoking the action.
     /// Prevents actions from being excessively called when bound to noisy UI events.
     /// Action calls are automatically grouped by call location. Use `observe(_:debounced:identifier:)` if you need custom debounce grouping.
     /// - Parameters:
-    ///   - stateChangeAsyncSequenceAction: The action to be debounced before invoking
+    ///   - stateSequence: The action to be debounced before invoking
     ///   - dueTime: The amount of time required to pass before invoking the most recent action
-    func observe<SomeAsyncSequence: AsyncSequence>(
-        _ stateChangeAsyncSequenceAction: @escaping () async -> SomeAsyncSequence,
+    func observeAsync<SomeAsyncSequence: AsyncSequence>(
+        _ stateSequence: @escaping () async -> SomeAsyncSequence,
         debounced dueTime: DispatchQueue.SchedulerTimeType.Stride,
         file: String = #file,
         line: UInt = #line
     ) where SomeAsyncSequence.Element == ViewState {
-        container.observe(stateChangeAsyncSequenceAction, debounced: dueTime, file: file, line: line)
+        container.observeAsync(stateSequence, debounced: dueTime, file: file, line: line)
     }
     
     /// Debounces the action calls by `dueTime`, then observes the async sequence of `State`s returned as a result of invoking the action.
     /// Prevents actions from being excessively called when bound to noisy UI events.
     /// Action calls are grouped by the provided `identifier`.
     /// - Parameters:
-    ///   - stateChangeAsyncSequenceAction: The action to be debounced before invoking
+    ///   - stateSequence: The action to be debounced before invoking
     ///   - dueTime: The amount of time required to pass before invoking the most recent action
     ///   - identifier: The identifier for grouping actions for debouncing
-    func observe<SomeAsyncSequence: AsyncSequence>(
-        _ stateChangeAsyncSequenceAction: @escaping () async -> SomeAsyncSequence,
+    func observeAsync<SomeAsyncSequence: AsyncSequence>(
+        _ stateSequence: @escaping () async -> SomeAsyncSequence,
         debounced dueTime: DispatchQueue.SchedulerTimeType.Stride,
         identifier: AnyHashable
     ) where SomeAsyncSequence.Element == ViewState {
-        container.observe(stateChangeAsyncSequenceAction, debounced: dueTime, identifier: identifier)
+        container.observeAsync(stateSequence, debounced: dueTime, identifier: identifier)
     }
     
     /// Debounces the action calls by `dueTime`, then observes the `State` returned as a result of invoking the action.
     /// Prevents actions from being excessively called when bound to noisy UI events.
     /// Action calls are automatically grouped by call location. Use `observe(_:debounced:identifier:)` if you need custom debounce grouping.
     /// - Parameters:
-    ///   - stateChangeAction: The action to be debounced before invoking
+    ///   - nextState: The action to be debounced before invoking
     ///   - dueTime: The amount of time required to pass before invoking the most recent action
     func observe(
-        _ stateChangeAction: @escaping @autoclosure () -> ViewState,
+        _ nextState: @escaping @autoclosure () -> ViewState,
         debounced dueTime: DispatchQueue.SchedulerTimeType.Stride,
         file: String = #file,
         line: UInt = #line
     ) {
-        container.observe(stateChangeAction(), debounced: dueTime, file: file, line: line)
+        container.observe(nextState, debounced: dueTime, file: file, line: line)
     }
     
     /// Debounces the action calls by `dueTime`, then observes the `State` returned as a result of invoking the action.

--- a/Tests/VSMTests/ViewStateRenderingTests+Observe.swift
+++ b/Tests/VSMTests/ViewStateRenderingTests+Observe.swift
@@ -30,14 +30,14 @@ class ViewStateRenderingTests_Observe: XCTestCase {
         let asyncAction: () async -> MockState = {
             .bar
         }
-        test(subject.container, expect: [.bar], when: { _ in subject.observe({ await asyncAction() }) })
+        test(subject.container, expect: [.bar], when: { _ in subject.observeAsync({ await asyncAction() }) })
     }
     
     func testObserveAsynchronousSequence() throws {
         let asyncAction: () async -> StateSequence<MockState> = {
             .init({ .bar })
         }
-        test(subject.container, expect: [.bar], when: { _ in subject.observe({ await asyncAction() }) })
+        test(subject.container, expect: [.bar], when: { _ in subject.observeAsync({ await asyncAction() }) })
     }
     
     func testObservePublisher() throws {

--- a/Tests/VSMTests/ViewStateRenderingTests+ObserveDebounce.swift
+++ b/Tests/VSMTests/ViewStateRenderingTests+ObserveDebounce.swift
@@ -110,13 +110,13 @@ class ViewStateRenderingTests_ObserveDebounce: XCTestCase {
         XCTAssertEqual(1, countableAction.count)
     }
     
-    /// Tests the asyncrhonous debounce action overloads
+    /// Tests the asynchronous debounce action overloads
     func testDebounce_AsyncOverload_DefaultId() async throws {
         let countableAction = CountableAsyncAction<MockState> {
             .bar
         }
         let actionCallSite: () -> Void = {
-            self.subject.observe({ await countableAction.invoke() }, debounced: .seconds(0.5))
+            self.subject.observeAsync({ await countableAction.invoke() }, debounced: .seconds(0.5))
         }
         
         actionCallSite()
@@ -127,13 +127,13 @@ class ViewStateRenderingTests_ObserveDebounce: XCTestCase {
         XCTAssertEqual(1, countableAction.count)
     }
     
-    /// Tests the asyncrhonous debounce action overloads
+    /// Tests the asynchronous debounce action overloads
     func testDebounce_AsyncOverload_CustomId() async throws {
         let countableAction = CountableAsyncAction<MockState> {
             .bar
         }
         let actionCallSite: () -> Void = {
-            self.subject.observe({ await countableAction.invoke() }, debounced: .seconds(0.5), identifier: "some_id")
+            self.subject.observeAsync({ await countableAction.invoke() }, debounced: .seconds(0.5), identifier: "some_id")
         }
         
         actionCallSite()
@@ -150,7 +150,7 @@ class ViewStateRenderingTests_ObserveDebounce: XCTestCase {
             .init({ .bar })
         }
         let actionCallSite: () -> Void = {
-            self.subject.observe({ await countableAction.invoke() }, debounced: .seconds(0.5))
+            self.subject.observeAsync({ await countableAction.invoke() }, debounced: .seconds(0.5))
         }
         
         actionCallSite()
@@ -161,13 +161,13 @@ class ViewStateRenderingTests_ObserveDebounce: XCTestCase {
         XCTAssertEqual(1, countableAction.count)
     }
     
-    /// Tests the asyncrhonous sequence debounce action overloads
+    /// Tests the asynchronous sequence debounce action overloads
     func testDebounce_AsyncSequenceOverload_CustomId() async throws {
         let countableAction = CountableAsyncSequenceAction<StateSequence<MockState>> {
             .init({ .bar })
         }
         let actionCallSite: () -> Void = {
-            self.subject.observe({ await countableAction.invoke() }, debounced: .seconds(0.5), identifier: "some_id")
+            self.subject.observeAsync({ await countableAction.invoke() }, debounced: .seconds(0.5), identifier: "some_id")
         }
         
         actionCallSite()
@@ -178,7 +178,7 @@ class ViewStateRenderingTests_ObserveDebounce: XCTestCase {
         XCTAssertEqual(1, countableAction.count)
     }
     
-    /// Tests the syncrhonous debounce action overloads
+    /// Tests the synchronous debounce action overloads
     func testDebounce_SynchronousOverload_DefaultId() async throws {
         let countableAction = CountableSynchronousAction<MockState> {
             .bar
@@ -195,7 +195,7 @@ class ViewStateRenderingTests_ObserveDebounce: XCTestCase {
         XCTAssertEqual(1, countableAction.count)
     }
     
-    /// Tests the syncrhonous debounce action overloads
+    /// Tests the synchronous debounce action overloads
     func testDebounce_SynchronousOverload_CustomId() async throws {
         let countableAction = CountableSynchronousAction<MockState> {
             .bar


### PR DESCRIPTION
## Description

This PR improves the stability and maintainability of VSM by fixing some bugs and providing clean protocols for the state container. (These protocols are also preparatory for the [VSM property wrappers](https://github.com/wayfair/vsm-ios/blob/main/ADRs/2022-12-08-PropertyWrappers-ADR.md) implementation which will follow shortly.)

Items of consequence in this PR:
- Fixed a bug where the iOS runtime was confusing synchronous closures with asynchronous closures, causing various timing issues. The  fix entails renaming `observe(_ awaitState: () async -> State)` to `observeAsync(_ awaitState: () async -> State)`
- Fixed a bug where the StateContainer was not updating the state synchronously on the main thread if both the subscription and the publisher's send function were being invoked on the main thread. This was causing various timing issues. (Added unit tests to prevent future regression)
- Added `StateContaining`, `StateObserving`, `StateBinding`, and `StatePublishing` protocols to pave the way for the incoming VSM property wrappers.
- Updated the debug functions and implementation to work more predictably, have more intuitive spelling, and have advanced options for more easily identifying state progression bugs in feature code.


## Type of Change

- [x] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [x] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wayfair/vsm-ios/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [ ] All code style checks pass
- [x] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
