### PR TITLE
Proposal: RenderedViewState Manual State Subscription

### DIFF
--- a/Sources/VSM/ViewState/RenderedViewState.swift
+++ b/Sources/VSM/ViewState/RenderedViewState.swift
@@ -135,29 +135,12 @@ public struct RenderedViewState<State> {
     }
 }
 
-// MARK: - RenderedViewState (StateRendering & Other Conformances)
-
-/// Provides functions for rendering state changes in UIKit views and view controllers
-@available(iOS 14.0, *)
-public protocol StateRendering {
-    /// Subscribes a UIKit view or view controller to render each state change. If not called, rendering will automatically start when the `state` property is first accessed.
-    ///
-    /// This function provides an option to control when the view begins rendering the current and subsequent states.
-    /// This can be especially important for views that inherently progress state by rendering the current state.
-    /// Directly calling the `render()` function on a view before the state rendering subscription is started will call the `render()` function twice.
-    /// Use this function to prevent that scenario.
-    ///
-    /// If the view or view controller accesses the `state` property in any of the early view lifecycle events (`viewDidLoad`, etc.), then calling this function is usually not necessary.
-    ///
-    /// Note that calling this function after accessing the `state` will have no effect.
-    /// Also, calling this function additional times will have no effect.
-    func startRendering<View: AnyObject>(on view: View)
-}
+// MARK: - RenderedViewState
 
 @available(iOS 14.0, *)
 public extension RenderedViewState {
     /// Provides functions for observing and rendering state changes in UIKit views and view controllers
-    struct RenderedContainer<State>: StateRendering {
+    struct RenderedContainer<State> {
         /// The wrapped state container for managing changes in state
         let container: StateContainer<State>
         /// Implicitly used by UIKit views to automatically call the provided function when the state changes
@@ -165,6 +148,18 @@ public extension RenderedViewState {
         /// Tracks state changes for invoking `render` when the state changes
         let stateDidChangeSubscriber: AtomicStateChangeSubscriber<State> = .init()
         
+        /// Subscribes a UIKit view or view controller to render each state change. If not called, rendering will automatically start when the `state` property is first accessed.
+        ///
+        /// This function provides an option to control when the view begins rendering the current and subsequent states.
+        /// This can be especially important for views that inherently progress state by rendering the current state.
+        /// Directly calling the `render()` function on a view before the state rendering subscription is started will call the `render()` function twice.
+        /// Use this function to prevent that scenario.
+        ///
+        /// If the view or view controller accesses the `state` property in any of the early view lifecycle events (`viewDidLoad`, etc.), then calling this function is usually not necessary.
+        ///
+        /// Note that calling this function after accessing the `state` will have no effect.
+        /// Also, calling this function additional times will have no effect.
+        /// - Parameter view: The view on which to subscribe
         public func startRendering<View>(on view: View) where View : AnyObject {
             stateDidChangeSubscriber
                 .subscribeOnce(to: container.publisher) { [weak view] newState in

--- a/Sources/VSM/ViewState/RenderedViewState.swift
+++ b/Sources/VSM/ViewState/RenderedViewState.swift
@@ -158,7 +158,7 @@ public protocol StateRendering {
 public extension RenderedViewState {
     /// Provides functions for observing and rendering state changes in UIKit views and view controllers
     struct RenderedContainer<State>: StateRendering {
-        /// The wrapped state container for managin changes in state
+        /// The wrapped state container for managing changes in state
         let container: StateContainer<State>
         /// Implicitly used by UIKit views to automatically call the provided function when the state changes
         let render: (AnyObject, State) -> Void

--- a/Sources/VSM/ViewState/RenderedViewState.swift
+++ b/Sources/VSM/ViewState/RenderedViewState.swift
@@ -5,6 +5,9 @@
 //  Created by Albert Bori on 12/23/22.
 //
 
+import Foundation
+import Combine
+
 /// **(UIKit Only)** Manages the view state for a UIView or UIViewController in VSM. Automatically calls `render()` when the view state changes.
 ///
 /// This property wrapper encapsulates a view's state property with an underlying `StateContainer` to provide the current view state .
@@ -53,35 +56,30 @@
 @propertyWrapper
 public struct RenderedViewState<State> {
     
-    let container: StateContainer<State>
-    /// Tracks state changes for invoking `render` when the state changes
-    let stateDidChangeSubscriber: AtomicStateChangeSubscriber<State> = .init()
-    /// Implicitly used by UIKit views to automatically call the provided function when the state changes
-    var render: (AnyObject, State) -> ()
+    let renderedContainer: RenderedContainer<State>
     
-    // MARK: - Encapsulating Properties
+    // MARK: Encapsulating Properties
 
     public var wrappedValue: State {
-        get { container.state }
+        get { projectedValue.container.state }
     }
 
-    public var projectedValue: some StateContaining<State> {
-        container
+    public var projectedValue: RenderedContainer<State> {
+        get { renderedContainer }
     }
     
-    // MARK: - Initializers
+    // MARK: Initializers
     
     /// **(UIKit only)** Instantiates the rendered view state with a custom state container.
     /// - Parameters:
     ///   - container: The state container that manages the view state.
     ///   - render: The function to call when the view state changes.
     public init<Parent: AnyObject>(container: StateContainer<State>, render: @escaping (Parent) -> () -> ()) {
-        self.container = container
         let anyRender: (Any, State) -> () = { parent, state in
             guard let parent = parent as? Parent else { return }
             render(parent)()
         }
-        self.render = anyRender
+        renderedContainer = RenderedContainer(container: container, render: anyRender)
     }
     
     /// **(UIKit only)** Instantiates the rendered view state with an initial value.
@@ -115,7 +113,7 @@ public struct RenderedViewState<State> {
         self.init(container: StateContainer(state: wrappedValue), render: render)
     }
     
-    // MARK: - Automatic Rendering
+    // MARK: Automatic Rendering
 
     /// Automatically calls `render()` when the state changes on any class that has a property decorated with this property wrapper. (Intended for UIKit only)
     ///
@@ -131,13 +129,116 @@ public struct RenderedViewState<State> {
     ) -> State {
         get {
             let wrapper = instance[keyPath: storageKeyPath]
-            wrapper
-                .stateDidChangeSubscriber
-                .subscribeOnce(to: wrapper.container.publisher) { [weak instance] newState in
-                    guard let instance else { return }
-                    wrapper.render(instance, newState)
-                }
+            wrapper.projectedValue.startRendering(on: instance)
             return wrapper.wrappedValue
         }
+    }
+}
+
+// MARK: - RenderedViewState (StateRendering & Other Conformances)
+
+/// Provides functions for rendering state changes in UIKit views and view controllers
+@available(iOS 14.0, *)
+public protocol StateRendering {
+    /// Subscribes a UIKit view or view controller to render each state change. If not called, rendering will automatically start when the `state` property is first accessed.
+    ///
+    /// This function provides an option to control when the view begins rendering the current and subsequent states.
+    /// This can be especially important for views that inherently progress state by rendering the current state.
+    /// Directly calling the `render()` function on a view before the state rendering subscription is started will call the `render()` function twice.
+    /// Use this function to prevent that scenario.
+    ///
+    /// If the view or view controller accesses the `state` property in any of the early view lifecycle events (`viewDidLoad`, etc.), then calling this function is usually not necessary.
+    ///
+    /// Note that calling this function after accessing the `state` will have no effect.
+    /// Also, calling this function additional times will have no effect.
+    func startRendering<View: AnyObject>(on view: View)
+}
+
+@available(iOS 14.0, *)
+public extension RenderedViewState {
+    /// Provides functions for observing and rendering state changes in UIKit views and view controllers
+    struct RenderedContainer<State>: StateRendering {
+        /// The wrapped state container for managin changes in state
+        let container: StateContainer<State>
+        /// Implicitly used by UIKit views to automatically call the provided function when the state changes
+        let render: (AnyObject, State) -> Void
+        /// Tracks state changes for invoking `render` when the state changes
+        let stateDidChangeSubscriber: AtomicStateChangeSubscriber<State> = .init()
+        
+        public func startRendering<View>(on view: View) where View : AnyObject {
+            stateDidChangeSubscriber
+                .subscribeOnce(to: container.publisher) { [weak view] newState in
+                    guard let view else { return }
+                    render(view, newState)
+                }
+        }
+    }
+}
+
+// Forwards protocol member calls to underlying state container
+@available(iOS 14.0, *)
+extension RenderedViewState.RenderedContainer: StateObserving & StatePublishing {
+    
+    // MARK: StatePublishing
+    // For more information about these members, view the protocol definition
+    
+    public var publisher: AnyPublisher<State, Never> {
+        container.publisher
+    }
+    
+    // MARK: StateObserving Implementation - Observe
+    // For more information about these members, view the protocol definition
+    
+    public func observe(_ statePublisher: AnyPublisher<State, Never>) {
+        container.observe(statePublisher)
+    }
+    
+    public func observe(_ nextState: State) {
+        container.observe(nextState)
+    }
+    
+    public func observeAsync(_ nextState: @escaping () async -> State) {
+        container.observeAsync(nextState)
+    }
+    
+    public func observeAsync<StateSequence: AsyncSequence>(
+        _ stateSequence: @escaping () async -> StateSequence
+    ) where StateSequence.Element == State {
+        container.observeAsync(stateSequence)
+    }
+    
+    // MARK: StateObserving Implementation - Debounce
+    // For more information about these members, view the protocol definition
+    
+    public func observe(
+        _ statePublisher: @escaping @autoclosure () ->  AnyPublisher<State, Never>,
+        debounced dueTime: DispatchQueue.SchedulerTimeType.Stride,
+        identifier: AnyHashable
+    ) {
+        container.observe(statePublisher(), debounced: dueTime, identifier: identifier)
+    }
+    
+    public func observe(
+        _ nextState: @escaping @autoclosure () -> State,
+        debounced dueTime: DispatchQueue.SchedulerTimeType.Stride,
+        identifier: AnyHashable
+    ) {
+        container.observe(nextState(), debounced: dueTime, identifier: identifier)
+    }
+    
+    public func observeAsync(
+        _ nextState: @escaping () async -> State,
+        debounced dueTime: DispatchQueue.SchedulerTimeType.Stride,
+        identifier: AnyHashable
+    ) {
+        container.observeAsync(nextState, debounced: dueTime, identifier: identifier)
+    }
+    
+    public func observeAsync<SomeAsyncSequence: AsyncSequence>(
+        _ stateSequence: @escaping () async -> SomeAsyncSequence,
+        debounced dueTime: DispatchQueue.SchedulerTimeType.Stride,
+        identifier: AnyHashable
+    ) where SomeAsyncSequence.Element == State {
+        container.observeAsync(stateSequence, debounced: dueTime, identifier: identifier)
     }
 }


### PR DESCRIPTION
## Description

Some potential problems were identified post-release in the `@RenderedViewState` property wrapper. This PR attempts to address those problems with a minor tweak to the property wrapper's API.

### Problem

`@RenderedViewState`’s automatic rendering starts when the `state` property is first accessed by the `UIViewController` (or `UIView`). In some cases, there is no immediate need to interact with the state during a view’s early life-cycle. In that scenario, the automatic rendering will never start.

In another case, it's possible to have duplicate state progression:

If you called `render()` in `viewDidLoad` as a way of kicking off the state observation, it would execute `render()`, which would access the state property, which would subscribe statePublisher to `render()`, which would immediately execute `render()`. So render would get called twice immediately.

In addition: If you have the following within your `render()` function, your `loaderModel.load()` will be called and observed twice instantly, potentially causing duplicate data operations on each usage.

```swift
func render {
  switch state {
  case .initialized(let loaderModel):
    $state.observe(loaderModel.load())
  ...
}
...
struct LoaderModel {
  func load() -> AnyPublisher<MyViewState, Never> {
    Just(.someState)
      .subscribe(on: DispatchQueue.global()) // <- first state returned NOT on main thread
      .eraseToAnyPublisher()
  }
}
```

The current workaround for this issue is to avoid using your `render()` function for progression state. Only use it for configuring views. (As seen in the VSM examples and documentation.)

These issues, combined with the inherent risk that Apple “could break” the magic subscript for accessing the wrapper’s containing object (thereby breaking the auto-rendering), inspires us to consider adding an explicit render subscription option for the `@RenderedViewState` property wrapper for these edge cases and for more cautious engineers/orgs.

### Solution

To address the problems above, this PR introduces a new function on the projected value of the `@RenderedViewState` property wrapper which enables engineers to (optionally) more directly control when the state subscription/auto-rendering begins. It can be used by simply calling `$state.startRendering(on: self)` in any view or view controller lifecycle event.

For example:

```swift
init(...) {
  _state = .init(wrappedValue: .initialized(LoaderModel()), render: Self.render)
  super.init(...)
}

override viewDidLoad() {
  super.viewDidLoad()
  $state.startRendering(on: self)
}
```

This is a non-breaking change which introduces additional capabilities. No migration is necessary.

The main drawback is that this new function may be misunderstood in its purpose and use. Clear documentation may be required to help encourage engineers to use this function properly.

### Considered Alternatives

The [Source](https://github.com/daniel-hall/SourceArchitecture/blob/main/Sources/SourceArchitecture/CoreTypes.swift#L57) architecture does something similar for UIKit views. However their approach differs. Instead of relying on fully automatic subscription to the state changes for rendering, the solution relies on an implicitly enforced pattern of always kicking off the automatic rendering with a manual call to `render()` in your `init`, `viewDidLoad` or `view[Will|Did]Appear`. To prevent the double-rendering problem, the internal workings of Source _always_ drops the first value when the state subscription starts.

If we were to adopt this approach, our code would _always_ look like this, regardless of the situation:

```swift
init(...) {
  _state = .init(wrappedValue: .initialized(LoaderModel()), render: Self.render)
  super.init(...)
}

override viewDidLoad() {
  super.viewDidLoad()
  render()
}
```

The reason that this solution was not chosen was because the double-render problem is a circumstantial edge case. The "80% case" is assumed to be that the render will automatically subscribe to state changes when the state is accessed/progressed in the  `init`, `viewDidLoad` or `view[Will|Did]Appear`, like so:

```swift
init(...) {
  _state = .init(wrappedValue: .initialized(LoaderModel()), render: Self.render)
  super.init(...)
}

override viewDidLoad() {
  super.viewDidLoad()
  if case .initialized(let loaderModel) = state {
    $state.observe(loaderModel.load())
  }
}
```

Not to mention, the proposed solution allows for both of these paradigms to coexist, providing a "no-thought 80% solution" and a simple workaround for the "20% solution".

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wayfair/vsm-ios/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
