### PR TITLE
willSet and didSet State Publishers

### DIFF
--- a/Demos/Shopping/Shopping/Views/Favorites/FavoritesView.swift
+++ b/Demos/Shopping/Shopping/Views/Favorites/FavoritesView.swift
@@ -38,7 +38,7 @@ struct FavoritesView: View {
             }
         }
         .navigationTitle("Favorites")
-        .onReceive($state.publisher) { state in
+        .onReceive($state.willSetPublisher) { state in
             if case .deletingError = state {
                 showErrorAlert = true
             }

--- a/Demos/Shopping/Shopping/Views/Settings/SettingsView.swift
+++ b/Demos/Shopping/Shopping/Views/Settings/SettingsView.swift
@@ -63,7 +63,7 @@ struct SettingsView: View {
                 .onChange(of: isStateBindingExampleEnabled) { enabled in
                     $state.observe(state.toggleIsStateBindingExampleEnabled(enabled))
                 }
-                .onReceive($state.publisher.map(\.isStateBindingExampleEnabled)) { enabled in
+                .onReceive($state.willSetPublisher.map(\.isStateBindingExampleEnabled)) { enabled in
                     isStateBindingExampleEnabled = enabled
                 }
                 .accessibilityIdentifier("State Binding Toggle")

--- a/Sources/VSM/StateContainer/StateContainer+Debug.swift
+++ b/Sources/VSM/StateContainer/StateContainer+Debug.swift
@@ -75,13 +75,13 @@ class StateContainerDebugLogger {
         
         if options.contains(.willSet) {
             publisher = publisher
-                .merge(with: container.$state
+                .merge(with: container.willSetPublisher
                     .map({ .init(name: "willSet", state: $0, description: "\($0)") }))
                 .eraseToAnyPublisher()
         }
         if options.contains(.didSet) {
             publisher = publisher
-                .merge(with: container.publisher
+                .merge(with: container.didSetPublisher
                     .map({ .init(name: "didSet", state: $0, description: "\($0)") }))
                 .eraseToAnyPublisher()
         }

--- a/Sources/VSM/StateContainer/StateContainer.swift
+++ b/Sources/VSM/StateContainer/StateContainer.swift
@@ -14,11 +14,6 @@ final public class StateContainer<State>: ObservableObject, StateContaining {
         }
     }
     
-    /// Publishes the State on `didSet` (main thread). For a `willSet` publisher, use the `$state` projected value.
-    public lazy var publisher: AnyPublisher<State, Never> = {
-        stateDidChangeSubject.eraseToAnyPublisher()
-    }()
-    
     /// Used for debug logging. Inert in non-DEBUG schemas.
     lazy var debugLogger: StateContainerDebugLogger = StateContainerDebugLogger()
     
@@ -63,6 +58,20 @@ final public class StateContainer<State>: ObservableObject, StateContaining {
     deinit {
         cancelRunningObservations()
     }
+    
+    // MARK: - StatePublishing
+    
+    /// Publishes the state on `didSet` (main thread). For a `willSet` publisher, use the `$state` projected value.
+    @available(*, deprecated, renamed: "didSetPublisher", message: "It has been renamed to didSetPublisher and will be removed in a future version.")
+    public var publisher: AnyPublisher<State, Never> { didSetPublisher }
+    
+    public lazy var willSetPublisher: AnyPublisher<State, Never> = {
+        $state.eraseToAnyPublisher()
+    }()
+    
+    public lazy var didSetPublisher: AnyPublisher<State, Never> = {
+        stateDidChangeSubject.eraseToAnyPublisher()
+    }()
 }
 
 // MARK: - Observe Function Overloads

--- a/Sources/VSM/StateContainer/StateContainer.swift
+++ b/Sources/VSM/StateContainer/StateContainer.swift
@@ -62,7 +62,7 @@ final public class StateContainer<State>: ObservableObject, StateContaining {
     // MARK: - StatePublishing
     
     /// Publishes the state on `didSet` (main thread). For a `willSet` publisher, use the `$state` projected value.
-    @available(*, deprecated, renamed: "didSetPublisher", message: "It has been renamed to didSetPublisher and will be removed in a future version.")
+    @available(*, deprecated, renamed: "didSetPublisher", message: "Renamed to didSetPublisher and will be removed in a future version")
     public var publisher: AnyPublisher<State, Never> { didSetPublisher }
     
     public lazy var willSetPublisher: AnyPublisher<State, Never> = {

--- a/Sources/VSM/StateContainer/StatePublishing.swift
+++ b/Sources/VSM/StateContainer/StatePublishing.swift
@@ -12,5 +12,15 @@ public protocol StatePublishing<State> {
     associatedtype State
     
     /// Publishes the state changes on the main thread
+    @available(*, deprecated, renamed: "didSetPublisher", message: "It has been renamed to didSetPublisher and will be removed in a future version.")
     var publisher: AnyPublisher<State, Never> { get }
+    
+    /// Publishes the state changes on the main thread before the current state is updated
+    ///
+    /// SwiftUI views should generally use this publisher when using `onReceive` to observe the state, especially if modifying other view properties in the `onReceive` closure.
+    ///
+    /// Views (SwiftUI & UIKit) can use this publisher to compare the current state with the future state to determine what view updates are necessary.
+    var willSetPublisher: AnyPublisher<State, Never> { get }
+    /// Publishes the state changes on the main thread after the current state is updated
+    var didSetPublisher: AnyPublisher<State, Never> { get }
 }

--- a/Sources/VSM/StateContainer/StatePublishing.swift
+++ b/Sources/VSM/StateContainer/StatePublishing.swift
@@ -12,7 +12,7 @@ public protocol StatePublishing<State> {
     associatedtype State
     
     /// Publishes the state changes on the main thread
-    @available(*, deprecated, renamed: "didSetPublisher", message: "It has been renamed to didSetPublisher and will be removed in a future version.")
+    @available(*, deprecated, renamed: "didSetPublisher", message: "Renamed to didSetPublisher and will be removed in a future version")
     var publisher: AnyPublisher<State, Never> { get }
     
     /// Publishes the state changes on the main thread before the current state is updated

--- a/Sources/VSM/ViewState/RenderedViewState.swift
+++ b/Sources/VSM/ViewState/RenderedViewState.swift
@@ -178,7 +178,7 @@ extension RenderedViewState.RenderedContainer: StateObserving & StatePublishing 
     // MARK: StatePublishing
     // For more information about these members, view the protocol definition
     
-    @available(*, deprecated, renamed: "didSetPublisher", message: "It has been renamed to didSetPublisher and will be removed in a future version.")
+    @available(*, deprecated, renamed: "didSetPublisher", message: "Renamed to didSetPublisher and will be removed in a future version")
     public var publisher: AnyPublisher<State, Never> {
         container.publisher
     }

--- a/Sources/VSM/ViewState/RenderedViewState.swift
+++ b/Sources/VSM/ViewState/RenderedViewState.swift
@@ -73,9 +73,9 @@ public struct RenderedViewState<State> {
     /// **(UIKit only)** Instantiates the rendered view state with a custom state container.
     /// - Parameters:
     ///   - container: The state container that manages the view state.
-    ///   - render: The function to call when the view state changes.
+    ///   - render: The function to call when the view state _did change_.
     public init<Parent: AnyObject>(container: StateContainer<State>, render: @escaping (Parent) -> () -> ()) {
-        let anyRender: (Any, State) -> () = { parent, state in
+        let anyRender: (AnyObject, State) -> () = { parent, state in
             guard let parent = parent as? Parent else { return }
             render(parent)()
         }
@@ -85,6 +85,7 @@ public struct RenderedViewState<State> {
     /// **(UIKit only)** Instantiates the rendered view state with an initial value.
     ///
     /// Example:
+    ///
     /// ```swift
     /// class MyViewController: UIViewController {
     ///     @RenderedViewState var state: MyViewState
@@ -105,7 +106,7 @@ public struct RenderedViewState<State> {
     ///
     /// - Parameters:
     ///   - wrappedValue: The view state to be managed by the state container.
-    ///   - render: The function to call when the view state changes.
+    ///   - render: The function to call when the view state _did change_.
     public init<Parent: AnyObject>(
         wrappedValue: State,
         render: @escaping (Parent) -> () -> ()
@@ -146,7 +147,7 @@ public extension RenderedViewState {
         /// Implicitly used by UIKit views to automatically call the provided function when the state changes
         let render: (AnyObject, State) -> Void
         /// Tracks state changes for invoking `render` when the state changes
-        let stateDidChangeSubscriber: AtomicStateChangeSubscriber<State> = .init()
+        let stateSubscriber: AtomicStateChangeSubscriber<State> = .init()
         
         /// Subscribes a UIKit view or view controller to render each state change. If not called, rendering will automatically start when the `state` property is first accessed.
         ///
@@ -161,8 +162,8 @@ public extension RenderedViewState {
         /// Also, calling this function additional times will have no effect.
         /// - Parameter view: The view on which to subscribe
         public func startRendering<View>(on view: View) where View : AnyObject {
-            stateDidChangeSubscriber
-                .subscribeOnce(to: container.publisher) { [weak view] newState in
+            stateSubscriber
+                .subscribeOnce(to: container.didSetPublisher) { [weak view] newState in
                     guard let view else { return }
                     render(view, newState)
                 }
@@ -177,8 +178,17 @@ extension RenderedViewState.RenderedContainer: StateObserving & StatePublishing 
     // MARK: StatePublishing
     // For more information about these members, view the protocol definition
     
+    @available(*, deprecated, renamed: "didSetPublisher", message: "It has been renamed to didSetPublisher and will be removed in a future version.")
     public var publisher: AnyPublisher<State, Never> {
         container.publisher
+    }
+    
+    public var willSetPublisher: AnyPublisher<State, Never> {
+        container.willSetPublisher
+    }
+    
+    public var didSetPublisher: AnyPublisher<State, Never> {
+        container.didSetPublisher
     }
     
     // MARK: StateObserving Implementation - Observe

--- a/Tests/VSMTests/AnyViewStateRendering.swift
+++ b/Tests/VSMTests/AnyViewStateRendering.swift
@@ -9,6 +9,7 @@ import SwiftUI
 import VSM
 
 /// A concrete test subject for testing various ViewStateRendering extensions
+@available(*, deprecated, message: "This type will be removed when ViewStateRendering is removed from the framework")
 struct AnyViewStateRendering<ViewState>: ViewStateRendering, View {
     var container: StateContainer<ViewState>
     var body: some View {

--- a/Tests/VSMTests/StateContainerTests.swift
+++ b/Tests/VSMTests/StateContainerTests.swift
@@ -366,4 +366,37 @@ class StateContainerTests: XCTestCase {
 
         negativeTest.waitForExpectations(timeout: 1)
     }
+    
+    @available(*, deprecated, message: "This test will be removed when the publisher property is removed from the framework")
+    func testStatePublisherTiming() {
+        let subject = StateContainer<MockState>(state: .foo)
+        let test = subject.publisher
+            .dropFirst()
+            .expect { state in
+                XCTAssertEqual(state, .bar)
+                XCTAssertEqual(subject.state, .bar)
+            }
+        subject.observe(.bar)
+        test.waitForExpectations(timeout: 1)
+    }
+    
+    func testEventStatePublisherTiming() {
+        // Assures that the willSet and didSet publishers emit values at the appropriate times
+        let subject = StateContainer<MockState>(state: .foo)
+        let willSetTest = subject.willSetPublisher
+            .dropFirst()
+            .expect { state in
+                XCTAssertEqual(state, .bar)
+                XCTAssertEqual(subject.state, .foo)
+            }
+        let didSetTest = subject.didSetPublisher
+            .dropFirst()
+            .expect { state in
+                XCTAssertEqual(state, .bar)
+                XCTAssertEqual(subject.state, .bar)
+            }
+        subject.observe(.bar)
+        willSetTest.waitForExpectations(timeout: 1)
+        didSetTest.waitForExpectations(timeout: 1)
+    }
 }

--- a/Tests/VSMTests/ViewStateRenderingTests+Bind.swift
+++ b/Tests/VSMTests/ViewStateRenderingTests+Bind.swift
@@ -10,6 +10,7 @@ import SwiftUI
 import XCTest
 import VSM
 
+@available(*, deprecated, message: "This test class will be removed when ViewStateRendering is removed from the framework")
 class ViewStateRenderingTests_Bind: XCTestCase {
     var subject: AnyViewStateRendering<MockBindableState>!
     var cancellables: Set<AnyCancellable> = []

--- a/Tests/VSMTests/ViewStateRenderingTests+Observe.swift
+++ b/Tests/VSMTests/ViewStateRenderingTests+Observe.swift
@@ -11,6 +11,7 @@ import XCTest
 import VSM
 
 /// Tests all forwarding Observe overloads on the `ViewStateRendering` protocol extension
+@available(*, deprecated, message: "This test class will be removed when ViewStateRendering is removed from the framework")
 class ViewStateRenderingTests_Observe: XCTestCase {
     var subject: AnyViewStateRendering<MockState>!
 

--- a/Tests/VSMTests/ViewStateRenderingTests+ObserveDebounce.swift
+++ b/Tests/VSMTests/ViewStateRenderingTests+ObserveDebounce.swift
@@ -10,6 +10,7 @@ import Combine
 import XCTest
 
 @available(macOS 12, *)
+@available(*, deprecated, message: "This test class will be removed when ViewStateRendering is removed from the framework")
 class ViewStateRenderingTests_ObserveDebounce: XCTestCase {
     var subject: AnyViewStateRendering<MockState>!
     var cancellables: Set<AnyCancellable> = []


### PR DESCRIPTION
## Description

This PR deprecates the `publisher` property for the `StateContainer` class and the `@ViewState` and `@RenderedViewState` property wrappers. It replaces the `publisher` property with two new properties called `willSetPublisher` and `didSetPublisher` that more accurately and explicitly indicate the publisher's timing.

### Reasoning

During early use of the new `@ViewState` and `@RenderedViewState` property wrappers, it was discovered that when observing the state changes in a SwiftUI view via `onReceive`, the `body` property had already been evaluated for this state change because it was happening on the underlying StateContainer's `willSet` event. This means that if an engineer then modifies any SwiftUI view property (i.e., `@State`, `@ObservedObject`, etc.) it will cause the `body` property to be reevaluated, wasting resources and potentially causing timing bugs. In cases where the view state is progressed within the `onReceive` property, is is possible to cause infinite recursion.

[Example Problem Scenario](https://gist.github.com/albertbori/b7998b5d625fc2c93cfe31ccda3f49bf) (Credit: @mlarandeau)

As a result, the willSet and didSet event publishers were created so that engineers could have more fine-grained control over the timing of the state observation code.

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wayfair/vsm-ios/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [x] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
