### PR TITLE
Added willSet-didSet to RenderedViewState

### DIFF
--- a/Demos/Shopping/Shopping/Views/Product/ProductDetailView/ProductDetailViewController.swift
+++ b/Demos/Shopping/Shopping/Views/Product/ProductDetailView/ProductDetailViewController.swift
@@ -80,8 +80,8 @@ class ProductDetailViewController: UIViewController {
         errorView.isHidden = true
     }
     
-    func render() {
-        switch state {
+    func render(newState: ProductDetailViewState) {
+        switch newState {
         case .viewing:
             // update the UI with the product details
             configureButton(saving: false)


### PR DESCRIPTION
## Description

As a followup to #31 , this PR restores some functionality that was lost with the introduction of the `@RenderedViewState` property wrapper: The ability for a UIKit view or view controller to render / subscribe to the state changes in the willSet event.

Restoring this capability through the `@RenderedViewState` property wrapper allows engineers to compare the current and future state. This can be helpful in preventing duplicate updates, unnecessary operations, or for fine-tuning animations or navigation.

Example Usage

```swift
class MyViewController: UIViewController {
    @RenderedViewState var state: MyViewState
    init(state: MyViewState) {
        _state = .init(wrappedValue: state, render: Self.render)
        super.init(bundle: nil, nib: nil)
    }
    func render(newState: MyViewState) {
        // Compare state (old value) against newState (new value) to determine appropriate actions
        if state != newState {
            ...
        }
        if newState.someValue {
            ...
            $state.observe(newState.someAction())
        }
    }
}
```

This is an additive change that does not affect current implementations. To opt into the functionality, as in the example above, the engineer only needs add a state parameter to the render function in question. This will automatically switch the state change event that causes the render function to be called from didSet to willSet. These details are called out in the functions DocC documentation.

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wayfair/vsm-ios/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
