### PR TITLE
Public API Unit Tests

### DIFF
--- a/Sources/VSM/StateContainer/StateObserving.swift
+++ b/Sources/VSM/StateContainer/StateObserving.swift
@@ -26,7 +26,7 @@ public protocol StateObserving<State> {
     
     /// Asynchronously renders the sequence of states on the view.
     /// - Parameter stateSequence: The sequence of states to render
-    func observeAsync<StateSequence: AsyncSequence>(_ stateSequence: @escaping () async -> StateSequence) where StateSequence.Element == State
+    func observeAsync<SomeAsyncSequence: AsyncSequence>(_ stateSequence: @escaping () async -> SomeAsyncSequence) where SomeAsyncSequence.Element == State
     
     // MARK: - Debounce
     

--- a/Sources/VSM/StateContainer/StateObserving.swift
+++ b/Sources/VSM/StateContainer/StateObserving.swift
@@ -101,7 +101,7 @@ public extension StateObserving {
     ///   - nextState: The action to be debounced before invoking
     ///   - dueTime: The amount of time required to pass before invoking the most recent action
     func observe(
-        _ nextState: @escaping () -> State,
+        _ nextState: @escaping @autoclosure () -> State,
         debounced dueTime: DispatchQueue.SchedulerTimeType.Stride,
         file: String = #file,
         line: UInt = #line

--- a/Sources/VSM/ViewStateRendering.swift
+++ b/Sources/VSM/ViewStateRendering.swift
@@ -111,7 +111,7 @@ public extension ViewStateRendering {
     
     /// Convenience accessor for the `StateContainer`'s `observe` function.
     /// Observes the states emitted as a result of invoking some asynchronous action that returns an asynchronous sequence
-    func observeAsync<StateSequence: AsyncSequence>(_ awaitStateSequence: @escaping () async -> StateSequence) where StateSequence.Element == ViewState {
+    func observeAsync<SomeAsyncSequence: AsyncSequence>(_ awaitStateSequence: @escaping () async -> SomeAsyncSequence) where SomeAsyncSequence.Element == ViewState {
         container.observeAsync(awaitStateSequence)
     }
 

--- a/Sources/VSM/ViewStateRendering.swift
+++ b/Sources/VSM/ViewStateRendering.swift
@@ -318,7 +318,7 @@ public extension ViewStateRendering {
         file: String = #file,
         line: UInt = #line
     ) {
-        container.observe(nextState, debounced: dueTime, file: file, line: line)
+        container.observe(nextState(), debounced: dueTime, file: file, line: line)
     }
     
     /// Debounces the action calls by `dueTime`, then observes the `State` returned as a result of invoking the action.

--- a/Tests/VSMTests/RenderedViewStateTests.swift
+++ b/Tests/VSMTests/RenderedViewStateTests.swift
@@ -1,0 +1,84 @@
+//
+//  RenderedViewStateTests.swift
+//  
+//
+//  Created by Albert Bori on 2/28/23.
+//
+
+@testable import VSM
+import XCTest
+
+@available(iOS 14.0, *)
+final class RenderedViewStateTests: XCTestCase {
+    
+    func testWillSetRender() {
+        struct StatePair: Equatable {
+            let current: MockState
+            let future: MockState
+        }
+        let expectedPairs: [StatePair] = [
+            .init(current: .foo, future: .foo),
+            .init(current: .foo, future: .bar),
+            .init(current: .bar, future: .baz)
+        ]
+        var actualPairs: [StatePair] = []
+        let subject = MockWillSetRenderer(initialState: MockState.foo) { currentState, futureState in
+            actualPairs.append(.init(current: currentState, future: futureState))
+        }
+        subject.$state.observe(.bar)
+        subject.$state.observe(.baz)
+        XCTAssertEqual(expectedPairs, actualPairs)
+    }
+
+    func testDidSetRender() {
+        let expectedValues: [MockState] = [ .foo, .bar, .baz ]
+        var actualValues: [MockState] = []
+        let subject = MockDidSetRenderer(initialState: MockState.foo) { newState in
+            actualValues.append(newState)
+        }
+        subject.$state.observe(.bar)
+        subject.$state.observe(.baz)
+        XCTAssertEqual(expectedValues, actualValues)
+    }
+
+}
+
+@available(iOS 14.0, *)
+private class MockWillSetRenderer<State> {
+    @RenderedViewState var state: State
+    var renderImpl: ((State, State) -> Void)?
+
+    init(initialState: State, renderImpl: ((State, State) -> Void)? = nil) {
+        _state = .init(wrappedValue: initialState, render: Self.renderOnWillSet)
+        self.renderImpl = renderImpl
+        $state.startRendering(on: self)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func renderOnWillSet(newState: State) {
+        renderImpl?(state, newState)
+    }
+}
+
+@available(iOS 14.0, *)
+private class MockDidSetRenderer<State> {
+    @RenderedViewState var state: State
+    var renderImpl: ((State) -> Void)?
+
+    init(initialState: State, renderImpl: ((State) -> Void)? = nil) {
+        _state = .init(wrappedValue: initialState, render: Self.renderOnDidSet)
+        self.renderImpl = renderImpl
+        $state.startRendering(on: self)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func renderOnDidSet() {
+        renderImpl?(state)
+    }
+}

--- a/Tests/VSMTests/StateObservingTests/RenderedViewStateObservingTests.swift
+++ b/Tests/VSMTests/StateObservingTests/RenderedViewStateObservingTests.swift
@@ -1,0 +1,24 @@
+//
+//  RenderedViewStateObservingTests.swift
+//  
+//
+//  Created by Albert Bori on 2/28/23.
+//
+
+@testable import VSM
+import XCTest
+
+@available(iOS 14.0, *)
+final class RenderedViewStateObservingTests: StateObservingTests {
+    
+    override func setUp() {
+        let renderedViewState = RenderedViewState(wrappedValue: MockState.foo, render: Self.render)
+        stateObservingSubject = renderedViewState.projectedValue
+        observedState = { renderedViewState.wrappedValue }
+        observedStatePublisher = renderedViewState.projectedValue.didSetPublisher
+    }
+        
+    func render() {
+        //no-op
+    }
+}

--- a/Tests/VSMTests/StateObservingTests/StateObservingTests.swift
+++ b/Tests/VSMTests/StateObservingTests/StateObservingTests.swift
@@ -1,0 +1,168 @@
+//
+//  StateObservingTests.swift
+//  
+//
+//  Created by Albert Bori on 2/27/23.
+//
+
+import Combine
+@testable import VSM
+import XCTest
+
+/// Tests the `StatContainer`'s implementation of `StateObserving` and acts as a base class for other `StateObserving` types to test their desired outcomes
+class StateObservingTests: XCTestCase {
+    var stateObservingSubject: (any StateObserving<MockState>)!
+    var observedState: (() -> MockState)!
+    var observedStatePublisher: AnyPublisher<MockState, Never>!
+    
+    private var subject: any StateObserving<MockState> { stateObservingSubject }
+    private var state: MockState { observedState() }
+    private var statePublisher: AnyPublisher<MockState, Never> { observedStatePublisher }
+    
+    override func setUp() {
+        let stateContainer = StateContainer<MockState>(state: .foo)
+        stateObservingSubject = stateContainer
+        observedState = { stateContainer.state }
+        observedStatePublisher = stateContainer.$state.eraseToAnyPublisher()
+    }
+    
+    override func tearDown() {
+        stateObservingSubject = nil
+        observedState = nil
+        observedStatePublisher = nil
+    }
+    
+    func testDefaultState() {
+        XCTAssertEqual(state, .foo)
+        statePublisher
+            .expect(.foo)
+            .waitForExpectations(timeout: 5)
+    }
+    
+    func testObserveStatePublisher_MainThread() {
+        let publisher = CurrentValueSubject<MockState, Never>(.bar)
+        subject.observe(publisher.eraseToAnyPublisher())
+        XCTAssertEqual(state, .bar)
+        publisher.send(.baz)
+        XCTAssertEqual(state, .baz)
+    }
+    
+    func testObserveStatePublisher_BackgroundThread() {
+        let publisher = CurrentValueSubject<MockState, Never>(.bar)
+        subject.observe(publisher.subscribe(on: DispatchQueue.global()).eraseToAnyPublisher())
+        XCTAssertEqual(state, .foo)
+        statePublisher
+            .dropFirst()
+            .expect({ _ in
+                XCTAssert(Thread.isMainThread, "Observed published-state action should sink on main thread.")
+            })
+            .expect(.bar)
+            .waitForExpectations(timeout: 5)
+    }
+    
+    func testObserveStatePublisher_Debounced() {
+        func thunk(state: MockState) {
+            subject.observe(Just(state).eraseToAnyPublisher(), debounced: 0.0000001)
+        }
+        thunk(state: .bar)
+        thunk(state: .baz)
+        thunk(state: .grault)
+        XCTAssertEqual(state, .foo)
+        statePublisher
+            .dropFirst()
+            .expect(.grault)
+            .waitForExpectations(timeout: 5)
+        
+    }
+    
+    func testObserveNextState() {
+        subject.observe(.bar)
+        XCTAssertEqual(state, .bar)
+    }
+    
+    func testObserveNextState_Debounced() {
+        func thunk(state: MockState) {
+            subject.observe(state, debounced: 0.0000001)
+        }
+        thunk(state: .bar)
+        thunk(state: .baz)
+        thunk(state: .grault)
+        XCTAssertEqual(state, .foo)
+        statePublisher
+            .dropFirst()
+            .expect(.grault)
+            .waitForExpectations(timeout: 5)
+    }
+    
+    func testObserveAsyncNextState_Synchronous() {
+        XCTExpectFailure("MainActor implicit main-thread optimization not yet supported")
+        @MainActor
+        func thunk() async -> MockState {
+            .bar
+        }
+        subject.observeAsync(thunk)
+        XCTAssertEqual(state, .bar)
+    }
+    
+    func testObserveAsyncNextState_Asynchronous() {
+        subject.observeAsync({ .bar })
+        XCTAssertEqual(state, .foo)
+        statePublisher
+            .dropFirst()
+            .expect(.bar)
+            .waitForExpectations(timeout: 5)
+    }
+    
+    func testObserveAsyncNextState_Debounced() {
+        func thunk(state: MockState) {
+            subject.observeAsync({ state }, debounced: 0.0000001)
+        }
+        thunk(state: .bar)
+        thunk(state: .baz)
+        thunk(state: .grault)
+        XCTAssertEqual(state, .foo)
+        statePublisher
+            .dropFirst()
+            .expect(.grault)
+            .waitForExpectations(timeout: 5)
+    }
+    
+    func testObserveAsyncStateSequence_Synchronous() {
+        XCTExpectFailure("MainActor implicit main-thread optimization not yet supported")
+        @MainActor
+        func thunk() async -> StateSequence<MockState> {
+            let bar: @MainActor () -> MockState = { .bar }
+            let baz: @MainActor () -> MockState = { .baz }
+            return StateSequence(bar, baz)
+        }
+        let test = statePublisher
+            .collect(3)
+            .expect([.foo, .bar, .baz])
+        subject.observeAsync(thunk)
+        XCTAssertEqual(state, .baz)
+        test.waitForExpectations(timeout: 5)
+    }
+    
+    func testObserveAsyncStateSequence_Asynchronous() {
+        let test = statePublisher
+            .collect(3)
+            .expect([.foo, .bar, .baz])
+        subject.observeAsync({ StateSequence<MockState>({ .bar }, { .baz }) })
+        XCTAssertEqual(state, .foo)
+        test.waitForExpectations(timeout: 5)
+    }
+    
+    func testObserveAsyncStateSequence_Debounced() {
+        func thunk(state: MockState) {
+            subject.observeAsync({ StateSequence<MockState>({ state }) }, debounced: 0.0000001)
+        }
+        thunk(state: .bar)
+        thunk(state: .baz)
+        thunk(state: .grault)
+        XCTAssertEqual(state, .foo)
+        statePublisher
+            .dropFirst()
+            .expect(.grault)
+            .waitForExpectations(timeout: 5)
+    }
+}

--- a/Tests/VSMTests/StateObservingTests/ViewStateObservingTests.swift
+++ b/Tests/VSMTests/StateObservingTests/ViewStateObservingTests.swift
@@ -1,0 +1,22 @@
+//
+//  ViewStateObservingTests.swift
+//  
+//
+//  Created by Albert Bori on 2/28/23.
+//
+
+@testable import VSM
+import XCTest
+import SwiftUI
+
+@available(iOS 14.0, *)
+final class ViewStateObservingTests: StateObservingTests {
+    
+    override func setUp() {
+        let viewState = ViewState(wrappedValue: MockState.foo)
+        stateObservingSubject = viewState.projectedValue
+        observedState = { viewState.wrappedValue }
+        observedStatePublisher = viewState.projectedValue.didSetPublisher
+    }
+
+}

--- a/Tests/VSMTests/StatePublishingTests/RenderedViewStatePublishingTests.swift
+++ b/Tests/VSMTests/StatePublishingTests/RenderedViewStatePublishingTests.swift
@@ -1,0 +1,24 @@
+//
+//  RenderedViewStatePublishingTests.swift
+//  
+//
+//  Created by Albert Bori on 2/28/23.
+//
+
+@testable import VSM
+import XCTest
+
+@available(iOS 14.0, *)
+final class RenderedViewStatePublishingTests: StatePublishingTests {
+    
+    override func setUp() {
+        let renderedViewState = RenderedViewState(wrappedValue: MockState.foo, render: Self.render)
+        statePublishingSubject = renderedViewState.projectedValue
+        progressState = { renderedViewState.projectedValue.observe(.bar) }
+        observedState = { renderedViewState.wrappedValue }
+    }
+
+    func render() {
+        // no-op
+    }
+}

--- a/Tests/VSMTests/StatePublishingTests/StatePublishingTests.swift
+++ b/Tests/VSMTests/StatePublishingTests/StatePublishingTests.swift
@@ -1,0 +1,68 @@
+//
+//  StatePublishingTests.swift
+//  
+//
+//  Created by Albert Bori on 2/28/23.
+//
+
+import Combine
+@testable import VSM
+import XCTest
+
+/// Tests the `StatContainer`'s implementation of `StatePublishing` and acts as a base class for other `StatePublishing` types to test their desired outcomes
+class StatePublishingTests: XCTestCase {
+    var statePublishingSubject: (any StatePublishing<MockState>)!
+    var progressState: (() -> Void)!
+    var observedState: (() -> MockState)!
+    
+    private var subject: any StatePublishing<MockState> { statePublishingSubject }
+    private var state: MockState { observedState() }
+    
+    override func setUp() {
+        let stateContainer = StateContainer<MockState>(state: .foo)
+        statePublishingSubject = stateContainer
+        progressState = { stateContainer.observe(.bar) }
+        observedState = { stateContainer.state }
+    }
+    
+    override func tearDown() {
+        statePublishingSubject = nil
+        progressState = nil
+        observedState = nil
+    }
+    
+    @available(*, deprecated, message: "Will be removed in a future version")
+    func testStatePublisher_SendOnDidSet() {
+        let test = subject
+            .publisher
+            .dropFirst()
+            .expect({ _ in XCTAssertEqual(self.state, .bar) })
+            .expect(.bar)
+        XCTAssertEqual(state, .foo)
+        progressState()
+        test.waitForExpectations(timeout: 5)
+    }
+    
+    func testWillSetStatePublisher() {
+        let test = subject
+            .willSetPublisher
+            .dropFirst()
+            .expect({ _ in XCTAssertEqual(self.state, .foo) })
+            .expect(.bar)
+        XCTAssertEqual(state, .foo)
+        progressState()
+        test.waitForExpectations(timeout: 5)
+        XCTAssertEqual(state, .bar)
+    }
+    
+    func testDidSetStatePublisher() {
+        let test = subject
+            .didSetPublisher
+            .dropFirst()
+            .expect({ _ in XCTAssertEqual(self.state, .bar) })
+            .expect(.bar)
+        XCTAssertEqual(state, .foo)
+        progressState()
+        test.waitForExpectations(timeout: 5)
+    }
+}

--- a/Tests/VSMTests/StatePublishingTests/ViewStatePublishingTests.swift
+++ b/Tests/VSMTests/StatePublishingTests/ViewStatePublishingTests.swift
@@ -1,0 +1,21 @@
+//
+//  ViewStatePublishingTests.swift
+//  
+//
+//  Created by Albert Bori on 2/28/23.
+//
+
+@testable import VSM
+import XCTest
+
+@available(iOS 14.0, *)
+final class ViewStatePublishingTests: StatePublishingTests {
+    
+    override func setUp() {
+        let viewState = ViewState(wrappedValue: MockState.foo)
+        statePublishingSubject = viewState.projectedValue
+        progressState = { viewState.projectedValue.observe(.bar) }
+        observedState = { viewState.wrappedValue }
+    }
+    
+}


### PR DESCRIPTION
## Description

This PR fills some gaps in code coverage for the VSM unit tests. Primarily in the RenderedViewState property wrapper and its projected value. It does this by consolidating and reorganizing unit tests around their respective public protocols. Using a default unit test case subclass, we can achieve the same test coverage for all public APIs for the StateContainer to ensure that all calls are forwarded correctly and that no inherited behavior is accidentally lost.

While it's a bit unconventional to have unit test base classes that contain actual tests, this approach ensures unit testing consistency between all public VSM APIs.

This PR also contains some minor fixes and tweaks, including one "spelling-only" breaking change for the debounced version of the `observe(_ nextState...)` function.

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [x] Refactor
- [ ] Documentation
- [x] Other (please describe): Unit tests

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wayfair/vsm-ios/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
