### PR TITLE
Auto-Rendering and State Behavior Documentation

### DIFF
--- a/Demos/Shopping/Shopping/Views/Product/ProductDetailView/ProductDetailViewController.swift
+++ b/Demos/Shopping/Shopping/Views/Product/ProductDetailView/ProductDetailViewController.swift
@@ -76,8 +76,7 @@ class ProductDetailViewController: UIViewController {
         loadProductImage(from: productDetail.imageURL)
         productImage.accessibilityIdentifier = "\(productDetail.name) Image"
         productDetailLabel.text = productDetail.description
-        confirmationView.isHidden = true
-        errorView.isHidden = true
+        $state.startRendering(on: self)
     }
     
     func render(newState: ProductDetailViewState) {

--- a/README.md
+++ b/README.md
@@ -85,11 +85,7 @@ The view observes and renders the state using the `ViewState` property wrapper. 
 
 ```swift
 struct BlogEntryView: View {
-    @ViewState var state: BlogEntryViewState
-
-    init() {
-        _state = .init(wrappedValue: .initialized(LoaderModel()))
-    }
+    @ViewState var state: BlogEntryViewState = .initialized(LoaderModel())
 
     var body: some View {
         switch state {

--- a/Sources/VSM/Documentation.docc/ComprehensiveGuide/ViewDefinition-SwiftUI.md
+++ b/Sources/VSM/Documentation.docc/ComprehensiveGuide/ViewDefinition-SwiftUI.md
@@ -307,9 +307,9 @@ You will most often see these types of data expressed as properties on a SwiftUI
 
 ### Comparing State Changes
 
-VSM provides additional tools for assisting in some of this view-centric logic for SwiftUI views. One such tool is the ``RenderedViewState/RenderedContainer/willSetPublisher`` view state publisher. This publisher gives the ability to update SwiftUI view properties or compare the current view state against the future view state when the view state changes.
+VSM provides additional tools for assisting in some of this view-centric logic for SwiftUI views. One such tool is ``RenderedViewState/RenderedContainer/willSetPublisher``. This publisher enables SwiftUI view properties to be modified in a performant way when the state changes. It also enables engineers to compare the current and future view states.
 
-Example
+The following example displays a progress view that shows the loading state of some imaginary data operation. It begins loading when the view first appears and then animates the progress bar as the bytes are loaded. The view utilizes an `@State` property for animating the progress view and keeps the value up to date by observing the view state's `willSetPublisher`.
 
 ```swift
 struct MyView: View {
@@ -325,9 +325,9 @@ struct MyView: View {
             }
             .onReceive($state.willSetPublisher) { newState in
                 switch (state, newState) {
-                case (.loading(let loadingModel), .loading(let newLoadingModel)):
-                    guard loadingModel.loadedBytes < newLoadingModel.loadedBytes else { return }
-                    print(">>> Animating progress from \(loadingModel.loadedBytes) to \(newLoadingModel.loadedBytes) bytes")
+                case (.loading(let oldLoadingModel), .loading(let newLoadingModel)):
+                    guard oldLoadingModel.loadedBytes < newLoadingModel.loadedBytes else { return }
+                    print(">>> Animating progress from \(oldLoadingModel.loadedBytes) to \(newLoadingModel.loadedBytes) bytes")
                     withAnimation() {
                         progress = newLoadingModel.loadedBytes / newLoadingModel.totalBytes
                     }

--- a/Sources/VSM/Documentation.docc/ComprehensiveGuide/ViewDefinition-UIKit.md
+++ b/Sources/VSM/Documentation.docc/ComprehensiveGuide/ViewDefinition-UIKit.md
@@ -158,17 +158,6 @@ The `loadingError` case shows the error view on top of all of the content and se
 
 The `loaded` state, however, does build and configure a new view because it will only ever be called once and it needs to pass data into the editing view which requires `UserData` for initialization. The loaded state also stops and hides the loading indicator and the error view (if previously shown).
 
-> Note: If a new view _must_ be repeatedly rebuilt due to state changes, be sure to properly clear the previous views, like so:
-
-```swift
-contentView.subviews.forEach { $0.removeFromSuperview() }
-children.forEach { child in
-    child.willMove(toParent: nil)
-    child.removeFromParent()
-    child.didMove(toParent: nil)
-}
-```
-
 ### Editing View
 
 If we go back up to the feature's flow chart and translate the editing behavior (the right section of the state machine) to a view state, we come up with the following view state:

--- a/Sources/VSM/Documentation.docc/ComprehensiveGuide/ViewDefinition-UIKit.md
+++ b/Sources/VSM/Documentation.docc/ComprehensiveGuide/ViewDefinition-UIKit.md
@@ -407,7 +407,7 @@ func render(_ newState: MyViewState) {
 }
 ```
 
-In the above example, the `state` view property still contains the previous view state value, while the parameter passed into the `render(_ newState: MyViewState)` function contains the new view state _just before the `state` property is changed to the new value_. This allows you to perform any logic or operations that require comparison of the current and future state.
+In the above example, the `state` view property still contains the previous view state value, while the parameter passed into the `render(_ newState: MyViewState)` function contains the new view state _just before the `state` property is changed to the new value_. This allows you to perform any logic or operations that require a comparison of the current and future states.
 
 ### Will-Set / Did-Set Publishers
 
@@ -418,7 +418,7 @@ Example
 ```swift
 class MyViewController: UIViewController {
     @RenderedViewState var state: MyViewState
-    var stateSubscriptions: Set<AnyCancellable> = []
+    private var stateSubscriptions: Set<AnyCancellable> = []
     ...
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/Sources/VSM/Documentation.docc/ComprehensiveGuide/ViewDefinition-UIKit.md
+++ b/Sources/VSM/Documentation.docc/ComprehensiveGuide/ViewDefinition-UIKit.md
@@ -8,6 +8,8 @@ VSM is a reactive architecture and as such is a natural fit for SwiftUI, but it 
 
 The purpose of the "View" in VSM is to render the current view state and provide the user access to the data and actions available in that state.
 
+In the examples found in this article, we will be using Storyboards. The code-first approach to UIKit can also be used by changing how you initialize your UIView or UIViewController.
+
 ## View Structure
 
 The basic structure of a UIKit VSM view is as follows:
@@ -31,11 +33,41 @@ class UserProfileViewController: UIViewController {
 }
 ```
 
-To turn any UIView or UIViewController into a "VSM View", define a property that holds our current state and decorate it with the `@RenderedViewState` property wrapper.
+To turn any UIView or UIViewController into a "VSM View", define a property that holds our current state and decorate it with the `@RenderedViewState` property wrapper. `@RenderViewState` is designed for UIKit and will not work in SwiftUI. (See <doc:ViewDefinition-SwiftUI> for more information.)
 
-**The UIKit-only `@RenderedViewState` property wrapper updates the view every time the state changes**. `@RenderedViewState` requires a `render` _function type_ parameter to call when the state changes. You must define this function in your UIView or UIViewController.
+**The `@RenderedViewState` property wrapper updates the view every time the state changes**. `@RenderedViewState` requires a `render` _function type_ parameter to call when the state changes. You must define this function in your UIView or UIViewController.
 
-> Note: In the examples found in this article, we will be using Storyboards. As a result, we used a custom `NSCoder` initializer. If you are using a code-first approach to UIKit, you can use whichever initialization mechanism is most appropriate.
+To kick off this automatic rendering, you must choose an appropriate UIView or UIViewController lifecycle event (`viewDidLoad`, `viewWillAppear`, etc.) and apply one of these two approaches:
+
+#### Auto-Render - Option A
+
+Automatic rendering will begin simply by accessing the `state` property. In VSM, it is common to begin your view's state journey by observing an action early in the view's lifecycle.
+
+Example
+
+```swift
+func viewDidLoad() {
+    super.viewDidLoad()
+    if case .initialized(let loaderModel) = state {
+        $state.observe(loaderModel.load())
+    }
+}
+```
+
+#### Auto-Render - Option B
+
+Call `$state.startRendering(on: self)` at any point after initialization. This won't progress your state, but it will cause the automatic rendering to begin. This is most commonly used when the view's state journey is begun by some user action (e.g. tapping a button) and not a view lifecycle event.
+
+Example
+
+```swift
+func viewDidLoad() {
+    super.viewDidLoad()
+    $state.startRendering(on: self)
+}
+```
+
+> Warning: If you fail to implement one of the above auto-render approaches, the `render` function will never be called and the view state will be inert.
 
 ## Displaying the State
 


### PR DESCRIPTION
## Description

This PR contains the following updates to documentation and demo app code:

- `starRendering` and the auto-rendering nuances have been documented in the UIKit view building guide.
- An example of `startRendering` usage has been added to the Shopping demo app.
- `willSetPublisher` documentation has been added to both the UIKit and SwiftUI view building guides.
- `didSetPublisher` documentation has been added to the UIKit view building guides.
- Documentation supporting the use of an anti-pattern has been removed from the UIKit view building guide. (Destroying and rebuilding subviews within the render function)
- The Readme VSM view example has been simplified to no longer use the (unnecessary) custom property wrapper initializer 

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [x] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wayfair/vsm-ios/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [ ] All code style checks pass
- [x] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
