### PR TITLE
Added support for tvOS and watchOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,13 +19,22 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Build and Test VSM
+      - name: Build and Test VSM on macOS
+        uses: sersoft-gmbh/xcodebuild-action@v2 # https://github.com/marketplace/actions/xcodebuild-action
+        with:
+          spm-package: ./
+          scheme: VSM
+          destination: platform=macOS,arch=x86_64
+          action: test
+      
+      - name: Build and Test VSM on iOS
         uses: sersoft-gmbh/xcodebuild-action@v2 # https://github.com/marketplace/actions/xcodebuild-action
         with:
           spm-package: ./
           scheme: VSM
           destination: platform=iOS Simulator,OS=latest,name=iPhone 14
           action: test
+
   
   test-swiftui-demo-app:
     runs-on: macos-12

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,22 @@ jobs:
           scheme: VSM
           destination: platform=iOS Simulator,OS=latest,name=iPhone 14
           action: test
+      
+      - name: Build and Test VSM on watchOS
+        uses: sersoft-gmbh/xcodebuild-action@v2 # https://github.com/marketplace/actions/xcodebuild-action
+        with:
+          spm-package: ./
+          scheme: VSM
+          destination: platform=watchOS Simulator,OS=latest,name=Apple Watch SE (40mm) (2nd generation)
+          action: test
+
+      - name: Build and Test VSM on tvOS
+        uses: sersoft-gmbh/xcodebuild-action@v2 # https://github.com/marketplace/actions/xcodebuild-action
+        with:
+          spm-package: ./
+          scheme: VSM
+          destination: platform=tvOS Simulator,OS=latest,name=Apple TV
+          action: test
 
   
   test-swiftui-demo-app:

--- a/Package.resolved
+++ b/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/albertbori/TestableCombinePublishers.git",
       "state" : {
-        "revision" : "c4581c15e3960af0b8e946193fc260a8deb128a3",
-        "version" : "1.0.4"
+        "revision" : "a053f58f21a0187817afd65b440911496809d21a",
+        "version" : "1.2.1"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,9 @@ let package = Package(
     name: "VSM",
     platforms: [
         .iOS(.v13),
-        .macOS(.v11)
+        .macOS(.v11),
+        .watchOS(.v6),
+        .tvOS(.v13)
     ],
     products: [
         .library(
@@ -16,7 +18,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
-        .package(url: "https://github.com/albertbori/TestableCombinePublishers.git", from: "1.0.0")
+        .package(url: "https://github.com/albertbori/TestableCombinePublishers.git", from: "1.2.1")
     ],
     targets: [
         .target(

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.0-4baaaa.svg)](CODE_OF_CONDUCT.md)
 [![Maintainer](https://img.shields.io/badge/Maintainer-Wayfair-7F187F)](https://wayfair.github.io)
 
-# VSM for Apple platforms
+# VSM for Apple Platforms
 
 VSM is a reactive architecture that is unidirectional, highly type-safe, behavior-driven, and clean. This repository hosts an open-source swift package framework for easily building features in VSM on app publicly available Apple platforms.
 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.0-4baaaa.svg)](CODE_OF_CONDUCT.md)
 [![Maintainer](https://img.shields.io/badge/Maintainer-Wayfair-7F187F)](https://wayfair.github.io)
 
-# VSM for iOS
+# VSM for Apple platforms
 
-VSM is a reactive architecture that is unidirectional, highly type-safe, behavior-driven, and clean. This repository hosts an open-source swift package framework for easily building features in VSM on iOS.
+VSM is a reactive architecture that is unidirectional, highly type-safe, behavior-driven, and clean. This repository hosts an open-source swift package framework for easily building features in VSM on app publicly available Apple platforms.
 
 ## Overview
 
@@ -114,7 +114,7 @@ For more detailed tutorials and documentation, visit the [VSM Documentation](htt
 
 ### Credits
 
-VSM for iOS is owned and [maintained](MAINTAINERS.md) by [Wayfair](https://www.wayfair.com/).
+VSM for Apple platforms is owned and [maintained](MAINTAINERS.md) by [Wayfair](https://www.wayfair.com/).
 
 ### Contributing
 
@@ -126,4 +126,4 @@ See [SECURITY.md](SECURITY.md).
 
 ### License
 
-VSM for iOS is released under the MIT license. See [LICENSE](LICENSE) for details.
+VSM for Apple platforms is released under the MIT license. See [LICENSE](LICENSE) for details.

--- a/Sources/VSM/StateObject+StateInit.swift
+++ b/Sources/VSM/StateObject+StateInit.swift
@@ -10,6 +10,8 @@ import SwiftUI
 
 @available(macOS 11.0, *)
 @available(iOS 14.0, *)
+@available(tvOS 14.0, *)
+@available(watchOS 7.0, *)
 @available(*, deprecated, message: "Use the @ViewState property wrapper instead.")
 public extension StateObject {
     

--- a/Sources/VSM/ViewState/ViewState+Debug.swift
+++ b/Sources/VSM/ViewState/ViewState+Debug.swift
@@ -8,6 +8,8 @@
 #if DEBUG
 
 @available(iOS 14.0, *)
+@available(tvOS 14.0, *)
+@available(watchOS 7.0, *)
 extension ViewState: _StateContainerStaticDebugging where State == Any { }
 
 #endif

--- a/Sources/VSM/ViewState/ViewState.swift
+++ b/Sources/VSM/ViewState/ViewState.swift
@@ -32,6 +32,8 @@ import SwiftUI
 /// }
 /// ```
 @available(iOS 14.0, *)
+@available(tvOS 14.0, *)
+@available(watchOS 7.0, *)
 @propertyWrapper
 public struct ViewState<State>: DynamicProperty {
     

--- a/Tests/VSMTests/StateObservingTests/ViewStateObservingTests.swift
+++ b/Tests/VSMTests/StateObservingTests/ViewStateObservingTests.swift
@@ -10,6 +10,7 @@ import XCTest
 import SwiftUI
 
 @available(iOS 14.0, *)
+@available(tvOS 14.0, *)
 final class ViewStateObservingTests: StateObservingTests {
     
     override func setUp() {

--- a/Tests/VSMTests/StatePublishingTests/ViewStatePublishingTests.swift
+++ b/Tests/VSMTests/StatePublishingTests/ViewStatePublishingTests.swift
@@ -9,6 +9,7 @@
 import XCTest
 
 @available(iOS 14.0, *)
+@available(tvOS 14.0, *)
 final class ViewStatePublishingTests: StatePublishingTests {
     
     override func setUp() {


### PR DESCRIPTION
## Description

This PR just adds support to use VSM on tvOS and watchOS. It also bumps the version of TestableCombinePublisher it that package also needed those platforms to be added in order to run VSM's unit tests on the new platforms.

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wayfair/vsm-ios/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
