### PR TITLE
Maintenance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Prepare Xcode
         uses: maxim-lobanov/setup-xcode@v1 # https://github.com/marketplace/actions/setup-xcode-version
         with:
-          xcode-version: 15.0.1
+          xcode-version: 14.3.1 # Xcode 15 has UI test runtime issues
 
       - name: Checkout
         uses: actions/checkout@v3
@@ -84,7 +84,7 @@ jobs:
       - name: Prepare Xcode
         uses: maxim-lobanov/setup-xcode@v1 # https://github.com/marketplace/actions/setup-xcode-version
         with:
-          xcode-version: 15.0.1
+          xcode-version: 14.3.1 # Xcode 15 has UI test runtime issues
 
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,12 +9,12 @@ on: # Rebuild any PRs and main branch changes
 
 jobs:
   test-vsm:
-    runs-on: macos-latest
+    runs-on: macos-13-arm64
     steps:
       - name: Prepare Xcode
         uses: maxim-lobanov/setup-xcode@v1 # https://github.com/marketplace/actions/setup-xcode-version
         with:
-          xcode-version: latest-stable
+          xcode-version: 15.0.1
 
       - name: Checkout
         uses: actions/checkout@v3
@@ -53,12 +53,12 @@ jobs:
 
   
   test-swiftui-demo-app:
-    runs-on: macos-latest
+    runs-on: macos-13-arm64
     steps:
       - name: Prepare Xcode
         uses: maxim-lobanov/setup-xcode@v1 # https://github.com/marketplace/actions/setup-xcode-version
         with:
-          xcode-version: latest-stable
+          xcode-version: 15.0.1
 
       - name: Checkout
         uses: actions/checkout@v3
@@ -72,12 +72,12 @@ jobs:
           action: test
 
   test-uikit-demo-app:
-    runs-on: macos-latest
+    runs-on: macos-13-arm64
     steps:
       - name: Prepare Xcode
         uses: maxim-lobanov/setup-xcode@v1 # https://github.com/marketplace/actions/setup-xcode-version
         with:
-          xcode-version: latest-stable
+          xcode-version: 15.0.1
 
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,41 +58,45 @@ jobs:
           scheme: VSM
           destination: platform=tvOS Simulator,OS=17.0,name=Apple TV 4K (3rd generation) (at 1080p)
           action: test
+
+  # The following jobs are disabled until further notice to unblock work
+  # Xcode currently has UI test runtime issues since Xcode 14.3
+  # These UI tests should be run manually by engineers until the Xcode runtime issues are resolved 
   
-  test-swiftui-demo-app:
-    runs-on: macos-13
-    steps:
-      - name: Prepare Xcode
-        uses: maxim-lobanov/setup-xcode@v1 # https://github.com/marketplace/actions/setup-xcode-version
-        with:
-          xcode-version: 14.3.1 # Xcode 15 has UI test runtime issues
+  # test-swiftui-demo-app:
+  #   runs-on: macos-13
+  #   steps:
+  #     - name: Prepare Xcode
+  #       uses: maxim-lobanov/setup-xcode@v1 # https://github.com/marketplace/actions/setup-xcode-version
+  #       with:
+  #         xcode-version: 14.3.1 # Xcode 15 has UI test runtime issues
 
-      - name: Checkout
-        uses: actions/checkout@v4
+  #     - name: Checkout
+  #       uses: actions/checkout@v4
 
-      - name: Build and Test Demo App
-        uses: sersoft-gmbh/xcodebuild-action@v2 # https://github.com/marketplace/actions/xcodebuild-action
-        with:
-          project: ./Demos/Shopping/Shopping.xcodeproj
-          scheme: Shopping
-          destination: platform=iOS Simulator,OS=17.0.1,name=iPhone 14
-          action: test
+  #     - name: Build and Test Demo App
+  #       uses: sersoft-gmbh/xcodebuild-action@v2 # https://github.com/marketplace/actions/xcodebuild-action
+  #       with:
+  #         project: ./Demos/Shopping/Shopping.xcodeproj
+  #         scheme: Shopping
+  #         destination: platform=iOS Simulator,OS=17.0.1,name=iPhone 14
+  #         action: test
 
-  test-uikit-demo-app:
-    runs-on: macos-13
-    steps:
-      - name: Prepare Xcode
-        uses: maxim-lobanov/setup-xcode@v1 # https://github.com/marketplace/actions/setup-xcode-version
-        with:
-          xcode-version: 14.3.1 # Xcode 15 has UI test runtime issues
+  # test-uikit-demo-app:
+  #   runs-on: macos-13
+  #   steps:
+  #     - name: Prepare Xcode
+  #       uses: maxim-lobanov/setup-xcode@v1 # https://github.com/marketplace/actions/setup-xcode-version
+  #       with:
+  #         xcode-version: 14.3.1 # Xcode 15 has UI test runtime issues
 
-      - name: Checkout
-        uses: actions/checkout@v4
+  #     - name: Checkout
+  #       uses: actions/checkout@v4
 
-      - name: (UIKit) Build and Test Demo App
-        uses: sersoft-gmbh/xcodebuild-action@v2 # https://github.com/marketplace/actions/xcodebuild-action
-        with:
-          project: ./Demos/Shopping/Shopping.xcodeproj
-          scheme: Shopping - UIKit
-          destination: platform=iOS Simulator,OS=17.0.1,name=iPhone 14
-          action: test
+  #     - name: (UIKit) Build and Test Demo App
+  #       uses: sersoft-gmbh/xcodebuild-action@v2 # https://github.com/marketplace/actions/xcodebuild-action
+  #       with:
+  #         project: ./Demos/Shopping/Shopping.xcodeproj
+  #         scheme: Shopping - UIKit
+  #         destination: platform=iOS Simulator,OS=17.0.1,name=iPhone 14
+  #         action: test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           spm-package: ./
           scheme: VSM
-          destination: platform=iOS Simulator,OS=latest,name=iPhone 14
+          destination: platform=iOS Simulator,OS=latest,name=iPhone 15
           action: test
       
       - name: Build and Test VSM on watchOS
@@ -68,7 +68,7 @@ jobs:
         with:
           project: ./Demos/Shopping/Shopping.xcodeproj
           scheme: Shopping
-          destination: platform=iOS Simulator,OS=latest,name=iPhone 14
+          destination: platform=iOS Simulator,OS=latest,name=iPhone 15
           action: test
 
   test-uikit-demo-app:
@@ -87,5 +87,5 @@ jobs:
         with:
           project: ./Demos/Shopping/Shopping.xcodeproj
           scheme: Shopping - UIKit
-          destination: platform=iOS Simulator,OS=latest,name=iPhone 14
+          destination: platform=iOS Simulator,OS=latest,name=iPhone 15
           action: test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,15 +19,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Build and Test VSM on macOS
+      - name: Build and Test VSM on macOS (Intel)
         uses: sersoft-gmbh/xcodebuild-action@v2 # https://github.com/marketplace/actions/xcodebuild-action
         with:
           spm-package: ./
           scheme: VSM
-          destination: platform=macOS,id=4203018E-580F-C1B5-9525-B745CECA79EB
+          destination: platform=macOS,arch=x86_64
           action: test
 
-      - name: Build and Test VSM on Mac Catalyst
+      - name: Build and Test VSM on Mac Catalyst (Intel)
         uses: sersoft-gmbh/xcodebuild-action@v2 # https://github.com/marketplace/actions/xcodebuild-action
         with:
           spm-package: ./

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on: # Rebuild any PRs and main branch changes
 
 jobs:
   test-vsm:
-    runs-on: macos-13-arm64
+    runs-on: macos-13
     steps:
       - name: Prepare Xcode
         uses: maxim-lobanov/setup-xcode@v1 # https://github.com/marketplace/actions/setup-xcode-version
@@ -53,7 +53,7 @@ jobs:
 
   
   test-swiftui-demo-app:
-    runs-on: macos-13-arm64
+    runs-on: macos-13
     steps:
       - name: Prepare Xcode
         uses: maxim-lobanov/setup-xcode@v1 # https://github.com/marketplace/actions/setup-xcode-version
@@ -72,7 +72,7 @@ jobs:
           action: test
 
   test-uikit-demo-app:
-    runs-on: macos-13-arm64
+    runs-on: macos-13
     steps:
       - name: Prepare Xcode
         uses: maxim-lobanov/setup-xcode@v1 # https://github.com/marketplace/actions/setup-xcode-version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Prepare Xcode
         uses: maxim-lobanov/setup-xcode@v1 # https://github.com/marketplace/actions/setup-xcode-version
         with:
-          xcode-version: 15.0.1
+          xcode-version: latest-stable
 
       - name: Checkout
         uses: actions/checkout@v3
@@ -58,7 +58,7 @@ jobs:
       - name: Prepare Xcode
         uses: maxim-lobanov/setup-xcode@v1 # https://github.com/marketplace/actions/setup-xcode-version
         with:
-          xcode-version: 15.0.1
+          xcode-version: latest-stable
 
       - name: Checkout
         uses: actions/checkout@v3
@@ -77,7 +77,7 @@ jobs:
       - name: Prepare Xcode
         uses: maxim-lobanov/setup-xcode@v1 # https://github.com/marketplace/actions/setup-xcode-version
         with:
-          xcode-version: 15.0.1
+          xcode-version: latest-stable
 
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           spm-package: ./
           scheme: VSM
-          destination: platform=iOS Simulator,OS=latest
+          destination: platform=iOS Simulator,OS=iOS 17.0,name=iPhone 15
           action: test
       
       - name: Build and Test VSM on watchOS
@@ -40,7 +40,7 @@ jobs:
         with:
           spm-package: ./
           scheme: VSM
-          destination: platform=watchOS Simulator,OS=latest
+          destination: platform=watchOS Simulator,OS=watchOS 10.0,name=Apple Watch Series 9 (45mm)
           action: test
 
       - name: Build and Test VSM on tvOS
@@ -48,7 +48,7 @@ jobs:
         with:
           spm-package: ./
           scheme: VSM
-          destination: platform=tvOS Simulator,OS=latest
+          destination: platform=tvOS Simulator,OS=tvOS 17.0,name=Apple TV 4K (3rd generation) (at 1080p)
           action: test
 
   
@@ -68,7 +68,7 @@ jobs:
         with:
           project: ./Demos/Shopping/Shopping.xcodeproj
           scheme: Shopping
-          destination: platform=iOS Simulator,OS=latest
+          destination: platform=iOS Simulator,OS=iOS 17.0,name=iPhone 15
           action: test
 
   test-uikit-demo-app:
@@ -87,5 +87,5 @@ jobs:
         with:
           project: ./Demos/Shopping/Shopping.xcodeproj
           scheme: Shopping - UIKit
-          destination: platform=iOS Simulator,OS=latest
+          destination: platform=iOS Simulator,OS=iOS 17.0,name=iPhone 15
           action: test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
           xcode-version: 15.0.1
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Build and Test VSM on macOS (Intel)
         uses: sersoft-gmbh/xcodebuild-action@v2 # https://github.com/marketplace/actions/xcodebuild-action
@@ -68,7 +68,7 @@ jobs:
           xcode-version: 14.3.1 # Xcode 15 has UI test runtime issues
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Build and Test Demo App
         uses: sersoft-gmbh/xcodebuild-action@v2 # https://github.com/marketplace/actions/xcodebuild-action
@@ -87,7 +87,7 @@ jobs:
           xcode-version: 14.3.1 # Xcode 15 has UI test runtime issues
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: (UIKit) Build and Test Demo App
         uses: sersoft-gmbh/xcodebuild-action@v2 # https://github.com/marketplace/actions/xcodebuild-action

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Prepare Xcode
         uses: maxim-lobanov/setup-xcode@v1 # https://github.com/marketplace/actions/setup-xcode-version
         with:
-          xcode-version: 15.1
+          xcode-version: 15.0.1
 
       - name: Checkout
         uses: actions/checkout@v3
@@ -58,7 +58,7 @@ jobs:
       - name: Prepare Xcode
         uses: maxim-lobanov/setup-xcode@v1 # https://github.com/marketplace/actions/setup-xcode-version
         with:
-          xcode-version: 15.1
+          xcode-version: 15.0.1
 
       - name: Checkout
         uses: actions/checkout@v3
@@ -77,7 +77,7 @@ jobs:
       - name: Prepare Xcode
         uses: maxim-lobanov/setup-xcode@v1 # https://github.com/marketplace/actions/setup-xcode-version
         with:
-          xcode-version: 15.1
+          xcode-version: 15.0.1
 
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
         with:
           project: ./Demos/Shopping/Shopping.xcodeproj
           scheme: Shopping
-          destination: platform=iOS Simulator,OS=17.0.1,name=iPhone 15
+          destination: platform=iOS Simulator,OS=17.0.1,name=iPhone 14
           action: test
 
   test-uikit-demo-app:
@@ -94,5 +94,5 @@ jobs:
         with:
           project: ./Demos/Shopping/Shopping.xcodeproj
           scheme: Shopping - UIKit
-          destination: platform=iOS Simulator,OS=17.0.1,name=iPhone 15
+          destination: platform=iOS Simulator,OS=17.0.1,name=iPhone 14
           action: test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,12 +9,12 @@ on: # Rebuild any PRs and main branch changes
 
 jobs:
   test-vsm:
-    runs-on: macos-12
+    runs-on: macos-13
     steps:
       - name: Prepare Xcode
         uses: maxim-lobanov/setup-xcode@v1 # https://github.com/marketplace/actions/setup-xcode-version
         with:
-          xcode-version: 14.2
+          xcode-version: 15.1
 
       - name: Checkout
         uses: actions/checkout@v3
@@ -53,12 +53,12 @@ jobs:
 
   
   test-swiftui-demo-app:
-    runs-on: macos-12
+    runs-on: macos-13
     steps:
       - name: Prepare Xcode
         uses: maxim-lobanov/setup-xcode@v1 # https://github.com/marketplace/actions/setup-xcode-version
         with:
-          xcode-version: 14.2
+          xcode-version: 15.1
 
       - name: Checkout
         uses: actions/checkout@v3
@@ -72,12 +72,12 @@ jobs:
           action: test
 
   test-uikit-demo-app:
-    runs-on: macos-12
+    runs-on: macos-13
     steps:
       - name: Prepare Xcode
         uses: maxim-lobanov/setup-xcode@v1 # https://github.com/marketplace/actions/setup-xcode-version
         with:
-          xcode-version: 14.2
+          xcode-version: 15.1
 
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,15 @@ jobs:
         with:
           spm-package: ./
           scheme: VSM
-          destination: platform=macOS
+          destination: platform=macOS,arch=x86_64,id=4203018E-580F-C1B5-9525-B745CECA79EB
+          action: test
+
+      - name: Build and Test VSM on Mac Catalyst
+        uses: sersoft-gmbh/xcodebuild-action@v2 # https://github.com/marketplace/actions/xcodebuild-action
+        with:
+          spm-package: ./
+          scheme: VSM
+          destination: platform=macOS,arch=x86_64,variant=Mac Catalyst
           action: test
       
       - name: Build and Test VSM on iOS

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on: # Rebuild any PRs and main branch changes
 
 jobs:
   test-vsm:
-    runs-on: macos-13
+    runs-on: macos-latest
     steps:
       - name: Prepare Xcode
         uses: maxim-lobanov/setup-xcode@v1 # https://github.com/marketplace/actions/setup-xcode-version
@@ -24,7 +24,7 @@ jobs:
         with:
           spm-package: ./
           scheme: VSM
-          destination: platform=macOS,arch=x86_64
+          destination: platform=macOS
           action: test
       
       - name: Build and Test VSM on iOS
@@ -32,7 +32,7 @@ jobs:
         with:
           spm-package: ./
           scheme: VSM
-          destination: platform=iOS Simulator,OS=latest,name=iPhone 15
+          destination: platform=iOS Simulator,OS=latest
           action: test
       
       - name: Build and Test VSM on watchOS
@@ -40,7 +40,7 @@ jobs:
         with:
           spm-package: ./
           scheme: VSM
-          destination: platform=watchOS Simulator,OS=latest,name=Apple Watch SE (40mm) (2nd generation)
+          destination: platform=watchOS Simulator,OS=latest
           action: test
 
       - name: Build and Test VSM on tvOS
@@ -48,12 +48,12 @@ jobs:
         with:
           spm-package: ./
           scheme: VSM
-          destination: platform=tvOS Simulator,OS=latest,name=Apple TV
+          destination: platform=tvOS Simulator,OS=latest
           action: test
 
   
   test-swiftui-demo-app:
-    runs-on: macos-13
+    runs-on: macos-latest
     steps:
       - name: Prepare Xcode
         uses: maxim-lobanov/setup-xcode@v1 # https://github.com/marketplace/actions/setup-xcode-version
@@ -68,11 +68,11 @@ jobs:
         with:
           project: ./Demos/Shopping/Shopping.xcodeproj
           scheme: Shopping
-          destination: platform=iOS Simulator,OS=latest,name=iPhone 15
+          destination: platform=iOS Simulator,OS=latest
           action: test
 
   test-uikit-demo-app:
-    runs-on: macos-13
+    runs-on: macos-latest
     steps:
       - name: Prepare Xcode
         uses: maxim-lobanov/setup-xcode@v1 # https://github.com/marketplace/actions/setup-xcode-version
@@ -87,5 +87,5 @@ jobs:
         with:
           project: ./Demos/Shopping/Shopping.xcodeproj
           scheme: Shopping - UIKit
-          destination: platform=iOS Simulator,OS=latest,name=iPhone 15
+          destination: platform=iOS Simulator,OS=latest
           action: test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           spm-package: ./
           scheme: VSM
-          destination: platform=macOS,arch=x86_64,id=4203018E-580F-C1B5-9525-B745CECA79EB
+          destination: platform=macOS,id=4203018E-580F-C1B5-9525-B745CECA79EB
           action: test
 
       - name: Build and Test VSM on Mac Catalyst
@@ -40,7 +40,7 @@ jobs:
         with:
           spm-package: ./
           scheme: VSM
-          destination: platform=iOS Simulator,OS=iOS 17.0,name=iPhone 15
+          destination: platform=iOS Simulator,OS=17.0.1,name=iPhone 15
           action: test
       
       - name: Build and Test VSM on watchOS
@@ -48,7 +48,7 @@ jobs:
         with:
           spm-package: ./
           scheme: VSM
-          destination: platform=watchOS Simulator,OS=watchOS 10.0,name=Apple Watch Series 9 (45mm)
+          destination: platform=watchOS Simulator,OS=10.0,name=Apple Watch Series 9 (45mm)
           action: test
 
       - name: Build and Test VSM on tvOS
@@ -56,9 +56,8 @@ jobs:
         with:
           spm-package: ./
           scheme: VSM
-          destination: platform=tvOS Simulator,OS=tvOS 17.0,name=Apple TV 4K (3rd generation) (at 1080p)
+          destination: platform=tvOS Simulator,OS=17.0,name=Apple TV 4K (3rd generation) (at 1080p)
           action: test
-
   
   test-swiftui-demo-app:
     runs-on: macos-13
@@ -76,7 +75,7 @@ jobs:
         with:
           project: ./Demos/Shopping/Shopping.xcodeproj
           scheme: Shopping
-          destination: platform=iOS Simulator,OS=iOS 17.0,name=iPhone 15
+          destination: platform=iOS Simulator,OS=17.0.1,name=iPhone 15
           action: test
 
   test-uikit-demo-app:
@@ -95,5 +94,5 @@ jobs:
         with:
           project: ./Demos/Shopping/Shopping.xcodeproj
           scheme: Shopping - UIKit
-          destination: platform=iOS Simulator,OS=iOS 17.0,name=iPhone 15
+          destination: platform=iOS Simulator,OS=17.0.1,name=iPhone 15
           action: test

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,7 +11,7 @@ jobs:
   markdown:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: ⬇️ lint markdown files # Lints all markdown (.md) files
         uses: avto-dev/markdown-lint@v1
         with:
@@ -20,7 +20,7 @@ jobs:
   renovate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: 🧼 lint renovate config # Validates changes to renovate.json config file
         uses: suzuki-shunsuke/github-action-renovate-config-validator@v0.1.3
         with:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Prepare Xcode
         uses: maxim-lobanov/setup-xcode@v1 # https://github.com/marketplace/actions/setup-xcode-version
         with:
-          xcode-version: 15.1
+          xcode-version: 15.0.1
 
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -37,19 +37,19 @@ jobs:
           xcode-version: 15.0.1
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Build Documentation
         run: ./Scripts/generate-docs.sh
 
       - name: Setup Pages
-        uses: actions/configure-pages@v3
+        uses: actions/configure-pages@v4
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v2
         with:
           path: './docs' # This path is coordinated with /generate-docs.sh
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v3

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -28,7 +28,7 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: macos-13-arm64
+    runs-on: macos-13
     steps:
 
       - name: Prepare Xcode

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -28,13 +28,13 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: macos-13
+    runs-on: macos-13-arm64
     steps:
 
       - name: Prepare Xcode
         uses: maxim-lobanov/setup-xcode@v1 # https://github.com/marketplace/actions/setup-xcode-version
         with:
-          xcode-version: latest-stable
+          xcode-version: 15.0.1
 
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Prepare Xcode
         uses: maxim-lobanov/setup-xcode@v1 # https://github.com/marketplace/actions/setup-xcode-version
         with:
-          xcode-version: 15.0.1
+          xcode-version: latest-stable
 
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -28,13 +28,13 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: macos-12
+    runs-on: macos-13
     steps:
 
       - name: Prepare Xcode
         uses: maxim-lobanov/setup-xcode@v1 # https://github.com/marketplace/actions/setup-xcode-version
         with:
-          xcode-version: 14.2
+          xcode-version: 15.1
 
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -12,7 +12,7 @@ jobs:
       pull-requests: write
     steps:
     - name: 📆 mark stale PRs # Automatically marks inactive PRs as stale
-      uses: actions/stale@v7
+      uses: actions/stale@v8
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         days-before-stale: 60

--- a/Demos/Shopping/Shopping.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Demos/Shopping/Shopping.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/albertbori/TestableCombinePublishers.git",
       "state" : {
-        "revision" : "c4581c15e3960af0b8e946193fc260a8deb128a3",
-        "version" : "1.0.4"
+        "revision" : "a053f58f21a0187817afd65b440911496809d21a",
+        "version" : "1.2.1"
       }
     },
     {

--- a/Demos/Shopping/ShoppingUITests/TestPages/SettingsPage.swift
+++ b/Demos/Shopping/ShoppingUITests/TestPages/SettingsPage.swift
@@ -13,8 +13,8 @@ struct SettingsPage: TestableUI, PushedPage {
     let previousView: AccountTabPage
     
     private var navBarTitle: XCUIElement { app.navigationBars["Settings"] }
-    private func toggle(for setting: Setting) -> XCUIElement { app.switches[setting.rawValue] }
-    
+    // 12/4/23 Added `.switches.firstMatch` due to bug: https://stackoverflow.com/a/76063451/300408
+    private func toggle(for setting: Setting) -> XCUIElement { app.switches[setting.rawValue].switches.firstMatch }
     
     init(app: XCUIApplication, previousView: AccountTabPage, file: StaticString = #file, line: UInt = #line) {
         self.app = app

--- a/Sources/VSM/ViewState/RenderedViewState.swift
+++ b/Sources/VSM/ViewState/RenderedViewState.swift
@@ -56,7 +56,7 @@ import Combine
 @propertyWrapper
 public struct RenderedViewState<State> {
     
-    let renderedContainer: RenderedContainer<State>
+    let renderedContainer: RenderedContainer
     
     // MARK: Encapsulating Properties
 
@@ -64,7 +64,7 @@ public struct RenderedViewState<State> {
         get { projectedValue.container.state }
     }
 
-    public var projectedValue: RenderedContainer<State> {
+    public var projectedValue: RenderedContainer {
         get { renderedContainer }
     }
     
@@ -189,7 +189,7 @@ public struct RenderedViewState<State> {
 @available(iOS 14.0, *)
 public extension RenderedViewState {
     /// Provides functions for observing and rendering state changes in UIKit views and view controllers
-    struct RenderedContainer<State> {
+    struct RenderedContainer {
         /// The wrapped state container for managing changes in state
         let container: StateContainer<State>
         /// Implicitly used by UIKit views to automatically call the provided function when the state changes

--- a/Tests/VSMTests/ViewStateRenderingTests+ObserveDebounce.swift
+++ b/Tests/VSMTests/ViewStateRenderingTests+ObserveDebounce.swift
@@ -56,9 +56,9 @@ class ViewStateRenderingTests_ObserveDebounce: XCTestCase {
     /// Asserts that multiple time-delayed action observations will each execute, if they are called far enough apart
     func testDebounce_DefaultId_SingleAction_Delayed_MultipleCalls() async throws {
         actionCallSite()
-        try await Task.sleep(seconds: 0.6)
+        try await Task.sleep(seconds: 1)
         actionCallSite()
-        try await Task.sleep(seconds: 1) // wait for debounce timeout
+        try await Task.sleep(seconds: 2) // wait for debounce timeout
         
         XCTAssertEqual(2, countableAction.count)
     }


### PR DESCRIPTION
## Description

This PR addresses some outstanding maintenance issues:
- The `RenderedContainer` type declared a generic alias of `State`, however, its enclosing type `RenderedViewState` already declared an alias of `State`, and therefore these generic aliases were contradicting. Swift produced a warning about this issue that, "will be an error in Swift 6". The simple fix was to remove the redundant generic alias.
- The Settings UI tests were failing 100% of the time due to a [bug(?) introduced in Xcode 14.3](https://stackoverflow.com/a/76063451/300408), which required the switch XCUIElement query to be further clarified by adding `.switches.firstMatch`.
- Upgraded [TestableCombinePublishers](https://github.com/albertbori/TestableCombinePublishers) to the next minor version to improve automatically equatable stability. 
- Upgraded CI jobs to use newer macOS and Xcode versions

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [x] Other (please describe) - Maintenance

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wayfair/vsm-ios/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
