### PR TITLE
Observe Some (Generic) Publisher

### DIFF
--- a/Demos/Shopping/Shopping.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Demos/Shopping/Shopping.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/albertbori/TestableCombinePublishers.git",
       "state" : {
-        "revision" : "c4581c15e3960af0b8e946193fc260a8deb128a3",
-        "version" : "1.0.4"
+        "revision" : "a053f58f21a0187817afd65b440911496809d21a",
+        "version" : "1.2.1"
       }
     },
     {

--- a/Demos/Shopping/Shopping/Views/Cart/CartButtonViewState.swift
+++ b/Demos/Shopping/Shopping/Views/Cart/CartButtonViewState.swift
@@ -11,22 +11,18 @@ import Foundation
 // MARK: - State & Model Definitions
 
 enum CartButtonViewState {
-    case initialized(CartCountLoaderModeling)
+    case initialized(CartCountLoaderModel)
     case loaded(cartItemCount: Int)
-}
-
-protocol CartCountLoaderModeling {
-    func loadCount() -> AnyPublisher<CartButtonViewState, Never>
 }
 
 // MARK: - Model Implementations
 
-struct CartCountLoaderModel: CartCountLoaderModeling {
+struct CartCountLoaderModel {
     typealias Dependencies = CartRepositoryDependency
     let dependencies: Dependencies
     
-    func loadCount() -> AnyPublisher<CartButtonViewState, Never> {
-        return dependencies.cartRepository.cartItemCountPublisher
+    func loadCount() -> some Publisher<CartButtonViewState, Never> {
+        dependencies.cartRepository.cartItemCountPublisher
             .map({ count in .loaded(cartItemCount: count) })
             .eraseToAnyPublisher()
     }

--- a/Sources/VSM/StateContainer/StateContainer.swift
+++ b/Sources/VSM/StateContainer/StateContainer.swift
@@ -79,7 +79,7 @@ final public class StateContainer<State>: ObservableObject, StateContaining {
 public extension StateContainer {
     
     // See StateObserving for details
-    func observe(_ statePublisher: AnyPublisher<State, Never>) {
+    func observe(_ statePublisher: some Publisher<State, Never>) {
         cancelRunningObservations()
         stateSubscription = statePublisher
             .sink { [weak self] newState in
@@ -149,7 +149,7 @@ public extension StateContainer {
     
     // See StateObserving for details
     func observe(
-        _ statePublisher: @escaping @autoclosure () -> AnyPublisher<State, Never>,
+        _ statePublisher: @escaping @autoclosure () -> some Publisher<State, Never>,
         debounced dueTime: DispatchQueue.SchedulerTimeType.Stride,
         identifier: AnyHashable
     ) {

--- a/Sources/VSM/StateContainer/StateObserving.swift
+++ b/Sources/VSM/StateContainer/StateObserving.swift
@@ -14,7 +14,7 @@ public protocol StateObserving<State> {
     
     /// Renders the states emitted by the publisher on the view.
     /// - Parameter statePublisher: The view state publisher to be observed for rendering the current view state
-    func observe(_ statePublisher: AnyPublisher<State, Never>)
+    func observe(_ statePublisher: some Publisher<State, Never>)
     
     /// Renders the next state on the view.
     /// - Parameter nextState: The next view state to render
@@ -37,7 +37,7 @@ public protocol StateObserving<State> {
     ///   - dueTime: The amount of time required to pass before invoking the most recent action
     ///   - identifier: (optional) The identifier for grouping actions for debouncing
     func observe(
-        _ statePublisher: @escaping @autoclosure () ->  AnyPublisher<State, Never>,
+        _ statePublisher: @escaping @autoclosure () -> some Publisher<State, Never>,
         debounced dueTime: DispatchQueue.SchedulerTimeType.Stride,
         identifier: AnyHashable
     )
@@ -87,7 +87,7 @@ public extension StateObserving {
     ///   - statePublisher: The action to be debounced before invoking
     ///   - dueTime: The amount of time required to pass before invoking the most recent action
     func observe(
-        _ statePublisher: @escaping @autoclosure () -> AnyPublisher<State, Never>,
+        _ statePublisher: @escaping @autoclosure () -> some Publisher<State, Never>,
         debounced dueTime: DispatchQueue.SchedulerTimeType.Stride,
         file: String = #file,
         line: UInt = #line

--- a/Sources/VSM/ViewState/RenderedViewState.swift
+++ b/Sources/VSM/ViewState/RenderedViewState.swift
@@ -56,7 +56,7 @@ import Combine
 @propertyWrapper
 public struct RenderedViewState<State> {
     
-    let renderedContainer: RenderedContainer<State>
+    let renderedContainer: RenderedContainer
     
     // MARK: Encapsulating Properties
 
@@ -64,7 +64,7 @@ public struct RenderedViewState<State> {
         get { projectedValue.container.state }
     }
 
-    public var projectedValue: RenderedContainer<State> {
+    public var projectedValue: RenderedContainer {
         get { renderedContainer }
     }
     
@@ -189,7 +189,7 @@ public struct RenderedViewState<State> {
 @available(iOS 14.0, *)
 public extension RenderedViewState {
     /// Provides functions for observing and rendering state changes in UIKit views and view controllers
-    struct RenderedContainer<State> {
+    struct RenderedContainer {
         /// The wrapped state container for managing changes in state
         let container: StateContainer<State>
         /// Implicitly used by UIKit views to automatically call the provided function when the state changes
@@ -257,7 +257,7 @@ extension RenderedViewState.RenderedContainer: StateObserving & StatePublishing 
     // MARK: StateObserving Implementation - Observe
     // For more information about these members, view the protocol definition
     
-    public func observe(_ statePublisher: AnyPublisher<State, Never>) {
+    public func observe(_ statePublisher: some Publisher<State, Never>) {
         container.observe(statePublisher)
     }
     
@@ -279,7 +279,7 @@ extension RenderedViewState.RenderedContainer: StateObserving & StatePublishing 
     // For more information about these members, view the protocol definition
     
     public func observe(
-        _ statePublisher: @escaping @autoclosure () ->  AnyPublisher<State, Never>,
+        _ statePublisher: @escaping @autoclosure () -> some Publisher<State, Never>,
         debounced dueTime: DispatchQueue.SchedulerTimeType.Stride,
         identifier: AnyHashable
     ) {


### PR DESCRIPTION
## Description

This PR introduces a small change which allows the observation of `some Publisher<Value, Failure>` instead of explicitly requiring `AnyPublisher<Value, Failure>`. This helps reduce the amount of typing when building view state models.

Previous:
```swift
struct LoaderModel {
    func load() -> AnyPublisher<MyViewState, Never> {
        Just(.loading)
            .merge(with: webRequestPublisher())
            .eraseToAnyPublisher()
    }
}
```

Current as of this PR:
```swift
struct LoaderModel {
    func load() -> some Publisher<MyViewState, Never> {
        Just(.loading)
            .merge(with: loadPublisher())
    }
}
```

Prior to this PR, the above code would cause an error if you tried to observe that function like so:
```swift
$state.observe(loaderModel.load())
```


## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wayfair/vsm-ios/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
