### PR TITLE
Mutatingcopyable keypath

### DIFF
--- a/Sources/VSM/MutatingCopyable.swift
+++ b/Sources/VSM/MutatingCopyable.swift
@@ -36,7 +36,7 @@ public extension MutatingCopyable {
     
     /// Creates a mutated copy of this type while simultaneously mutating the value at the provided KeyPath.
     ///
-    /// - Parameter keyPath: The KeyPath of the property you want to mutate. Please not that this property MUST be a `var` in order to change it's value using this method.
+    /// - Parameter keyPath: The KeyPath of the property you want to mutate. Please not that this property MUST be a `var` in order to change its value using this method.
     /// - Parameter value: The new value you want set on the property.
     /// - Returns: A mutated copy of this type.
     func copy<T>(mutatingPath keyPath: WritableKeyPath<Self, T>, value: T) -> Self {

--- a/Sources/VSM/MutatingCopyable.swift
+++ b/Sources/VSM/MutatingCopyable.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-/// Extend a value type with the ability to copy and mutate in a single line of code
+/// Extend a value type with the ability to copy and mutate in a single line of code.
 ///
 /// Example Usage
 /// ```swift
@@ -11,19 +11,37 @@ import Foundation
 ///         // Save username
 ///         return self.copy(mutating: { $0.username = username })
 ///     }
+///
+///     // OR
+///
+///     func update(username newValue: String) -> Self {
+///         // Save username
+///         return self.copy(mutating: \.username, value: newValue)
+///     }
 /// }
 /// ```
 public protocol MutatingCopyable { }
 
 public extension MutatingCopyable {
     
-    /// Creates a mutated copy of this type
-    /// 
-    /// - Parameter mutator: The function that mutates the copy of this type
-    /// - Returns: A mutated copy of this type
+    /// Creates a mutated copy of this type.
+    ///
+    /// - Parameter mutator: The function that mutates the copy of this type.
+    /// - Returns: A mutated copy of this type.
     func copy(mutating mutator: (inout Self) -> Void) -> Self {
         var copy = self
         mutator(&copy)
+        return copy
+    }
+    
+    /// Creates a mutated copy of this type while simultaneously mutating the value at the provided KeyPath.
+    ///
+    /// - Parameter keyPath: The KeyPath of the property you want to mutate. Please not that this property MUST be a `var` in order to change it's value using this method.
+    /// - Parameter value: The new value you want set on the property.
+    /// - Returns: A mutated copy of this type.
+    func copy<T>(mutatingPath keyPath: WritableKeyPath<Self, T>, value: T) -> Self {
+        var copy = self
+        copy[keyPath: keyPath] = value
         return copy
     }
 }

--- a/Tests/VSMTests/MutatingCopyableTests.swift
+++ b/Tests/VSMTests/MutatingCopyableTests.swift
@@ -1,0 +1,35 @@
+//
+//  MutatingCopyableTests.swift
+//
+//
+//  Created by Albert Bori on 12/6/23.
+//
+
+@testable import VSM
+import XCTest
+
+final class MutatingCopyableTests: XCTestCase {
+    struct Subject: MutatingCopyable {
+        var bar: String
+        var baz: Bool
+    }
+    
+    func testMutatingCopyableClosure() {
+        let subject = Subject(bar: "old", baz: false)
+        let result = subject.copy {
+            $0.bar = "new"
+            $0.baz = true
+        }
+        XCTAssertEqual(result.bar, "new")
+        XCTAssertEqual(result.baz, true)
+    }
+    
+    func testMutatingCopyableKeyPath() {
+        let subject = Subject(bar: "old", baz: false)
+        let result = subject
+            .copy(mutatingPath: \.bar, value: "new")
+            .copy(mutatingPath: \.baz, value: true)
+        XCTAssertEqual(result.bar, "new")
+        XCTAssertEqual(result.baz, true)
+    }
+}


### PR DESCRIPTION
## Description

This PR adds an additional method to MutatingCopyable that uses KeyPath instead of a closure to mutate a property on a struct and return a new copy of that struct with the modifications. Unit tests included.

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wayfair/vsm-ios/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
