### PR TITLE
Vision os support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Prepare Xcode
         uses: maxim-lobanov/setup-xcode@v1 # https://github.com/marketplace/actions/setup-xcode-version
         with:
-          xcode-version: 15.0.1
+          xcode-version: 15.2.0
 
       - name: Checkout
         uses: actions/checkout@v4
@@ -57,6 +57,14 @@ jobs:
           spm-package: ./
           scheme: VSM
           destination: platform=tvOS Simulator,OS=17.0,name=Apple TV 4K (3rd generation) (at 1080p)
+          action: test
+      
+      - name: Build and Test VSM on visionOS
+        uses: sersoft-gmbh/xcodebuild-action@v3 # https://github.com/marketplace/actions/xcodebuild-action
+        with:
+          spm-package: ./
+          scheme: VSM
+          destination: platform=visionOS Simulator,OS=1.0,name=Apple Vision Pro
           action: test
 
   # The following jobs are disabled until further notice to unblock work

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Prepare Xcode
         uses: maxim-lobanov/setup-xcode@v1 # https://github.com/marketplace/actions/setup-xcode-version
         with:
-          xcode-version: 15.0.1
+          xcode-version: 15.2.0
 
       - name: Checkout
         uses: actions/checkout@v4

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.7
+// swift-tools-version: 5.9
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -9,7 +9,8 @@ let package = Package(
         .iOS(.v13),
         .macOS(.v11),
         .watchOS(.v6),
-        .tvOS(.v13)
+        .tvOS(.v13),
+        .visionOS(.v1)
     ],
     products: [
         .library(

--- a/Sources/VSM/StateObject+StateInit.swift
+++ b/Sources/VSM/StateObject+StateInit.swift
@@ -12,6 +12,7 @@ import SwiftUI
 @available(iOS 14.0, *)
 @available(tvOS 14.0, *)
 @available(watchOS 7.0, *)
+@available(visionOS 1.0, *)
 @available(*, deprecated, message: "Use the @ViewState property wrapper instead.")
 public extension StateObject {
     

--- a/Sources/VSM/ViewState/RenderedViewState.swift
+++ b/Sources/VSM/ViewState/RenderedViewState.swift
@@ -53,6 +53,7 @@ import Combine
 /// }
 /// ```
 @available(iOS 14.0, *)
+@available(visionOS 1.0, *)
 @propertyWrapper
 public struct RenderedViewState<State> {
     
@@ -187,6 +188,7 @@ public struct RenderedViewState<State> {
 // MARK: - RenderedViewState
 
 @available(iOS 14.0, *)
+@available(visionOS 1.0, *)
 public extension RenderedViewState {
     /// Provides functions for observing and rendering state changes in UIKit views and view controllers
     struct RenderedContainer {
@@ -236,6 +238,7 @@ public extension RenderedViewState {
 
 // Forwards protocol member calls to underlying state container
 @available(iOS 14.0, *)
+@available(visionOS 1.0, *)
 extension RenderedViewState.RenderedContainer: StateObserving & StatePublishing {
     
     // MARK: StatePublishing

--- a/Sources/VSM/ViewState/ViewState+Debug.swift
+++ b/Sources/VSM/ViewState/ViewState+Debug.swift
@@ -7,9 +7,11 @@
 
 #if DEBUG
 
+@available(macOS 11, *)
 @available(iOS 14.0, *)
 @available(tvOS 14.0, *)
 @available(watchOS 7.0, *)
+@available(visionOS 1.0, *)
 extension ViewState: _StateContainerStaticDebugging where State == Any { }
 
 #endif

--- a/Sources/VSM/ViewState/ViewState.swift
+++ b/Sources/VSM/ViewState/ViewState.swift
@@ -31,9 +31,11 @@ import SwiftUI
 ///     }
 /// }
 /// ```
+@available(macOS 11, *)
 @available(iOS 14.0, *)
 @available(tvOS 14.0, *)
 @available(watchOS 7.0, *)
+@available(visionOS 1.0, *)
 @propertyWrapper
 public struct ViewState<State>: DynamicProperty {
     


### PR DESCRIPTION
## Description

This PR simply enabled visionOS as a deployable target for VSM. This included making the following changes:

* I had to bump the version of Swift we are using to 5.9 in order to get support for visionOS as a platform
* Updated the Package manifest to include visionOS as a platform target
* Bumped the version of Xcode CI uses up to Xcode 15.2 (required to enable testing on the visionOS simulator)

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [x] Other: Enabled new platform to build on

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wayfair/vsm-ios/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
