### PR TITLE
Added specific support for mac Catalyst as a deployable platform target

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -8,6 +8,7 @@ let package = Package(
     platforms: [
         .iOS(.v13),
         .macOS(.v11),
+        .macCatalyst(.v13),
         .watchOS(.v6),
         .tvOS(.v13),
         .visionOS(.v1)


### PR DESCRIPTION
## Description

Very tiny PR to explicitly add Mac Catalyst as a deployable build target for VSM. Until tests in CI where already there, this is just to cover our bases in case something changes in Xcode in a future release.

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [x] Other: New Platform

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wayfair/vsm-ios/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
