### PR TITLE
Added new method to StateContainer that takes a StateSequence instace

### DIFF
--- a/Sources/VSM/StateContainer/StateObserving.swift
+++ b/Sources/VSM/StateContainer/StateObserving.swift
@@ -82,7 +82,7 @@ public protocol StateObserving<State> {
         identifier: AnyHashable
     )
     
-    /// Calls an async closure that returns a asynchronous sequence states. Those states are rendered by the view in the order received.
+    /// Calls an async closure that returns an asynchronous sequence of states. Those states are rendered by the view in the order received.
     /// Calls to this function are debounced to prevent excessive execution from noisy events.
     /// - Parameters:
     ///   - stateSequence: The action to be debounced before invoking

--- a/Sources/VSM/StateContainer/StateObserving.swift
+++ b/Sources/VSM/StateContainer/StateObserving.swift
@@ -28,7 +28,7 @@ public protocol StateObserving<State> {
     /// - Parameter nextState: An async closure that returns the next state to render.
     func observeAsync(_ nextState: @escaping () async -> State)
     
-    /// Calls an async closure that returns a asynchronous sequence states. Those states are rendered by the view in the order received.
+    /// Calls an async closure that returns an asynchronous sequence of states. Those states are rendered by the view in the order received.
     /// - Parameter stateSequence: An async closure that returns a sequence of states.
     func observeAsync<SomeAsyncSequence: AsyncSequence>(_ stateSequence: @escaping () async -> SomeAsyncSequence) where SomeAsyncSequence.Element == State
     

--- a/Sources/VSM/StateContainer/StateObserving.swift
+++ b/Sources/VSM/StateContainer/StateObserving.swift
@@ -17,15 +17,19 @@ public protocol StateObserving<State> {
     func observe(_ statePublisher: some Publisher<State, Never>)
     
     /// Renders the next state on the view.
-    /// - Parameter nextState: The next view state to render
+    /// - Parameter nextState: The next view state to render.
     func observe(_ nextState: State)
     
+    /// Renders an asynchronous sequence states returned on the view.
+    /// - Parameter stateSequence: A sequence of states to render.
+    func observe<SomeAsyncSequence: AsyncSequence>(_ stateSequence: SomeAsyncSequence) where SomeAsyncSequence.Element == State
+    
     /// Asynchronously renders the next state on the view.
-    /// - Parameter nextState: The next view state to render
+    /// - Parameter nextState: An async closure that returns the next state to render.
     func observeAsync(_ nextState: @escaping () async -> State)
     
-    /// Asynchronously renders the sequence of states on the view.
-    /// - Parameter stateSequence: The sequence of states to render
+    /// Calls an async closure that returns a asynchronous sequence states. Those states are rendered by the view in the order received.
+    /// - Parameter stateSequence: An async closure that returns a sequence of states.
     func observeAsync<SomeAsyncSequence: AsyncSequence>(_ stateSequence: @escaping () async -> SomeAsyncSequence) where SomeAsyncSequence.Element == State
     
     // MARK: - Debounce
@@ -54,6 +58,18 @@ public protocol StateObserving<State> {
         identifier: AnyHashable
     )
     
+    /// Renders an asynchronous sequence states returned on the view.
+    /// Calls to this function are debounced to prevent excessive execution from noisy events.
+    /// - Parameters:
+    ///   - stateSequence: The action to be debounced before invoking
+    ///   - dueTime: The amount of time required to pass before invoking the most recent action
+    ///   - identifier: (optional) The identifier for grouping actions for debouncing
+    func observe<SomeAsyncSequence: AsyncSequence>(
+        _ stateSequence: SomeAsyncSequence,
+        debounced dueTime: DispatchQueue.SchedulerTimeType.Stride,
+        identifier: AnyHashable
+    ) where SomeAsyncSequence.Element == State
+    
     /// Asynchronously renders the next state on the view.
     /// Calls to this function are debounced to prevent excessive execution from noisy events.
     /// - Parameters:
@@ -66,7 +82,7 @@ public protocol StateObserving<State> {
         identifier: AnyHashable
     )
     
-    /// Asynchronously renders the sequence of states on the view.
+    /// Calls an async closure that returns a asynchronous sequence states. Those states are rendered by the view in the order received.
     /// Calls to this function are debounced to prevent excessive execution from noisy events.
     /// - Parameters:
     ///   - stateSequence: The action to be debounced before invoking
@@ -109,6 +125,20 @@ public extension StateObserving {
         observe(nextState(), debounced: dueTime, identifier: HashedIdentifier(file, line))
     }
     
+    /// Renders the sequence of asynchronous states returned on the view.
+    /// Calls to this function are debounced to prevent excessive execution from noisy events.
+    /// - Parameters:
+    ///   - stateSequence: The action to be debounced before invoking
+    ///   - dueTime: The amount of time required to pass before invoking the most recent action
+    func observe<SomeAsyncSequence: AsyncSequence>(
+        _ stateSequence: SomeAsyncSequence,
+        debounced dueTime: DispatchQueue.SchedulerTimeType.Stride,
+        file: String = #file,
+        line: UInt = #line
+    ) where SomeAsyncSequence.Element == State {
+        observe(stateSequence, debounced: dueTime, identifier: HashedIdentifier(file, line))
+    }
+    
     /// Asynchronously renders the next state on the view.
     /// Calls to this function are debounced to prevent excessive execution from noisy events.
     /// - Parameters:
@@ -123,7 +153,7 @@ public extension StateObserving {
         observeAsync(nextState, debounced: dueTime, identifier: HashedIdentifier(file, line))
     }
     
-    /// Asynchronously renders the sequence of states on the view.
+    /// Calls an async closure that returns a asynchronous sequence states. Those states are rendered by the view in the order received.
     /// Calls to this function are debounced to prevent excessive execution from noisy events.
     /// - Parameters:
     ///   - stateSequence: The action to be debounced before invoking

--- a/Sources/VSM/StateContainer/StateObserving.swift
+++ b/Sources/VSM/StateContainer/StateObserving.swift
@@ -58,7 +58,7 @@ public protocol StateObserving<State> {
         identifier: AnyHashable
     )
     
-    /// Renders an asynchronous sequence states returned on the view.
+    /// Renders an asynchronous sequence of states returned on the view.
     /// Calls to this function are debounced to prevent excessive execution from noisy events.
     /// - Parameters:
     ///   - stateSequence: The action to be debounced before invoking

--- a/Sources/VSM/StateContainer/StateObserving.swift
+++ b/Sources/VSM/StateContainer/StateObserving.swift
@@ -153,7 +153,7 @@ public extension StateObserving {
         observeAsync(nextState, debounced: dueTime, identifier: HashedIdentifier(file, line))
     }
     
-    /// Calls an async closure that returns a asynchronous sequence states. Those states are rendered by the view in the order received.
+    /// Calls an async closure that returns an asynchronous sequence of states. Those states are rendered by the view in the order received.
     /// Calls to this function are debounced to prevent excessive execution from noisy events.
     /// - Parameters:
     ///   - stateSequence: The action to be debounced before invoking

--- a/Sources/VSM/ViewState/RenderedViewState.swift
+++ b/Sources/VSM/ViewState/RenderedViewState.swift
@@ -278,6 +278,11 @@ extension RenderedViewState.RenderedContainer: StateObserving & StatePublishing 
         container.observeAsync(stateSequence)
     }
     
+    public func observe<SomeAsyncSequence>(_ stateSequence: SomeAsyncSequence) 
+    where SomeAsyncSequence : AsyncSequence, State == SomeAsyncSequence.Element {
+        container.observe(stateSequence)
+    }
+    
     // MARK: StateObserving Implementation - Debounce
     // For more information about these members, view the protocol definition
     
@@ -295,6 +300,10 @@ extension RenderedViewState.RenderedContainer: StateObserving & StatePublishing 
         identifier: AnyHashable
     ) {
         container.observe(nextState(), debounced: dueTime, identifier: identifier)
+    }
+    
+    public func observe<SomeAsyncSequence>(_ stateSequence: SomeAsyncSequence, debounced dueTime: DispatchQueue.SchedulerTimeType.Stride, identifier: AnyHashable) where SomeAsyncSequence : AsyncSequence, State == SomeAsyncSequence.Element {
+        container.observe(stateSequence, debounced: dueTime, identifier: identifier)
     }
     
     public func observeAsync(

--- a/Tests/VSMTests/StateObservingTests/StateObservingTests.swift
+++ b/Tests/VSMTests/StateObservingTests/StateObservingTests.swift
@@ -165,4 +165,27 @@ class StateObservingTests: XCTestCase {
             .expect(.grault)
             .waitForExpectations(timeout: 5)
     }
+    
+    func testObserveStateSequence() {
+        let test = statePublisher
+            .collect(3)
+            .expect([.foo, .bar, .baz])
+        subject.observe(StateSequence<MockState>({ .bar }, { .baz }))
+        XCTAssertEqual(state, .foo)
+        test.waitForExpectations(timeout: 5)
+    }
+    
+    func testObserveStateSequence_Debounced() {
+        func thunk(state: MockState) {
+            subject.observe(StateSequence<MockState>({ state }), debounced: 0.0000001)
+        }
+        thunk(state: .bar)
+        thunk(state: .baz)
+        thunk(state: .grault)
+        XCTAssertEqual(state, .foo)
+        statePublisher
+            .dropFirst()
+            .expect(.grault)
+            .waitForExpectations(timeout: 5)
+    }
 }


### PR DESCRIPTION
## Description

I've been using VSM more and more inside of Swift Concurrency code and notice that I keep repeating the same mistake over and over. When ever I write a function on a state model that returns a StateSequence, I mark that function as async even though inside said function I don't call any async functions. I believe it's because current the only way to have StateContainer to observe a StateSequence you need to call the `observeAsync` method which takes an async closure that returns a `StateSequence`.

Take this method as an example;
```swift
func getFirstPage(using datasource: Datasource) async -> StateSequence<PagedListViewState> {
    .init({ .fetchingFirstPage }, { await fetchingPage(using: datasource) })
}
```

I wrote it this way because when I call it I typically write it like this:
```swift
$state.observeAsync { await viewModel.getFirstPage(using: datasource) }
```

But this is entirely unnecessary because creating a new instance of StateSequence is not an async options. StateSequence models an array of async closures that return a `State`. iterating through the sequence is an async operation.

So in this PR I added a new overload to the `observe` method that I think is a better fit when you need to only observer a StateSequence, but creating that sequence is not asynchronous. Taking the same code as above I would now write the function that returns the StateSequence like this:
```swift
func getFirstPage(using datasource: Datasource) -> StateSequence<PagedListViewState> {
    .init({ .fetchingFirstPage }, { await fetchingPage(using: datasource) })
}
```

And when I go to observe those state changes I would call the new observe method that would look like this:
```swift
$state.observe(viewModel.getFirstPage(using: datasource))
```

I think this should prevent other users from making the same mistake I keep making.

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wayfair/vsm-ios/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
