### PR TITLE
New Observe function to support Pull To Refresh in SwiftUI

### DIFF
--- a/Demos/Shopping/Shopping/Views/Products/ProductsView.swift
+++ b/Demos/Shopping/Shopping/Views/Products/ProductsView.swift
@@ -50,7 +50,24 @@ struct ProductsView: View {
                 Text("No products available.")
             }
         } else {
-            let columns = Array(repeating: GridItem(.flexible()), count: 2)
+            loadedGridContentView(columns: Array(repeating: GridItem(.flexible()), count: 2), loadedModel: loadedModel)
+        }
+    }
+    
+    @ViewBuilder
+    func loadedGridContentView(columns: [GridItem], loadedModel: ProductsLoadedModeling) -> some View {
+        if #available(iOS 16, *) {
+            ScrollView(.vertical, showsIndicators: false) {
+                LazyVGrid(columns: columns) {
+                    ForEach(loadedModel.products, id: \.id) { product in
+                        ProductGridItemView(dependencies: dependencies, product: product)
+                    }
+                }
+            }
+            .refreshable {
+                await $state.waitFor { await loadedModel.refreshProducts() }
+            }
+        } else {
             ScrollView(.vertical, showsIndicators: false) {
                 LazyVGrid(columns: columns) {
                     ForEach(loadedModel.products, id: \.id) { product in

--- a/Demos/Shopping/ShoppingTests/ProductsViewStateTests.swift
+++ b/Demos/Shopping/ShoppingTests/ProductsViewStateTests.swift
@@ -53,7 +53,8 @@ class ProductsViewStateTests: XCTestCase {
     
     /// Tests the navigation binding action for `ProductsLoadedModel`
     func testNavigation() throws {
-        let subject = ProductsLoadedModel(products: [], productDetailId: nil)
+        let mockDependencies = MockAppDependencies.noOp
+        let subject = ProductsLoadedModel(dependencies: mockDependencies, products: [], productDetailId: nil)
         let output = subject.showProductDetail(id: 1)
         if case ProductsViewState.loaded(let loadedModel) = output {
             XCTAssertEqual(loadedModel.productDetailId, 1)

--- a/Sources/VSM/StateContainer/StateObserving.swift
+++ b/Sources/VSM/StateContainer/StateObserving.swift
@@ -28,6 +28,9 @@ public protocol StateObserving<State> {
     /// - Parameter nextState: An async closure that returns the next state to render.
     func observeAsync(_ nextState: @escaping () async -> State)
     
+    @MainActor
+    func waitFor(_ nextState: @escaping () async -> State) async -> Void
+    
     /// Calls an async closure that returns an asynchronous sequence of states. Those states are rendered by the view in the order received.
     /// - Parameter stateSequence: An async closure that returns a sequence of states.
     func observeAsync<SomeAsyncSequence: AsyncSequence>(_ stateSequence: @escaping () async -> SomeAsyncSequence) where SomeAsyncSequence.Element == State

--- a/Sources/VSM/ViewState/RenderedViewState.swift
+++ b/Sources/VSM/ViewState/RenderedViewState.swift
@@ -240,6 +240,11 @@ public extension RenderedViewState {
 @available(iOS 14.0, *)
 @available(visionOS 1.0, *)
 extension RenderedViewState.RenderedContainer: StateObserving & StatePublishing {
+    @MainActor
+    public func waitFor(_ nextState: @escaping () async -> State) async {
+        return await container.waitFor(nextState)
+    }
+    
     
     // MARK: StatePublishing
     // For more information about these members, view the protocol definition

--- a/Tests/VSMTests/Mocks/MockViewState.swift
+++ b/Tests/VSMTests/Mocks/MockViewState.swift
@@ -5,7 +5,7 @@
 //  Created by Albert Bori on 7/21/22.
 //
 
-enum MockState {
+enum MockState: Sendable {
     case foo
     case bar
     case baz


### PR DESCRIPTION
## Description

SwiftUI has a unique way of support Pull to Refresh. To enable the feature you need to support the `refreshable` view modifier with takes an async closure. The refresh "task" run and when it completes, SwiftUI will then refresh the view.

The problem we run into with VSM is that when using the existing observable functions inside the refreshable async task, state gets updated before the task completes. This then causes a complete refresh of the view which has two side effects:

1. It cancels the refreshable task
2. The update causes the entire view to "snap into place" which is VERY jarring to see as a user. Instead of the content smoothly animating back up into place it snaps right into position.

What this PR does is adds a new "

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wayfair/vsm-ios/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass