### PR TITLE
Bump TestableCombinePublishers

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/albertbori/TestableCombinePublishers.git",
       "state" : {
-        "revision" : "a053f58f21a0187817afd65b440911496809d21a",
-        "version" : "1.2.1"
+        "revision" : "9ac94c59aca1df2d109da9899418f1388c1438ed",
+        "version" : "2.0.1"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
-        .package(url: "https://github.com/albertbori/TestableCombinePublishers.git", from: "1.2.1")
+        .package(url: "https://github.com/albertbori/TestableCombinePublishers.git", from: "2.0.1")
     ],
     targets: [
         .target(


### PR DESCRIPTION
## Description

Bumps the `TestableCombinePublisher` dependency to [`2.0.1`](https://github.com/albertbori/TestableCombinePublishers/releases/tag/2.0.1).

This has no breaking changes for this repo.

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [X] Other - Version bump

## Checklist

- [X] I have read the [contributing guidelines](https://github.com/wayfair/vsm-ios/blob/main/CONTRIBUTING.md)
- [X] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [X] Functionality is documented
- [X] All code style checks pass
- [X] New code contribution is covered by automated tests
- [X] All new and existing tests pass
