### PR TITLE
Signpost performance

### DIFF
--- a/Demos/Shopping (Swift 6)/Shopping/Views/Cart/CartView.swift
+++ b/Demos/Shopping (Swift 6)/Shopping/Views/Cart/CartView.swift
@@ -23,7 +23,8 @@ struct CartView: View {
         _state = .init(
             wrappedValue: .initialized(CartLoaderModel(dependencies: dependencies)),
             observedViewType: Self.self,
-            loggingEnabled: true
+            loggingEnabled: true,
+            signpostsEnabled: true
         )
         _cartCountStore = .init(wrappedValue: CartCountStore(dependencies: dependencies))
     }

--- a/Sources/VSM/AsyncStateContainer.swift
+++ b/Sources/VSM/AsyncStateContainer.swift
@@ -311,7 +311,7 @@ public extension AsyncStateContainer {
         
         cancelRunningObservations()
 
-        let interval = tracer.beginInterval("State", id: tracer.makeSignpostID(), stateName(nextState))
+        let interval = tracer.beginInterval("State", id: tracer.makeSignpostID(), message: tracedStateName(nextState))
 
         performStateChange(nextState)
 
@@ -343,7 +343,7 @@ public extension AsyncStateContainer {
             }
 
             self.performStateChange(nextStateValue)
-            interval.end(self.stateName(nextStateValue))
+            interval.end(message: self.tracedStateName(nextStateValue))
         }
     }
 
@@ -375,7 +375,7 @@ public extension AsyncStateContainer {
                 return
             }
             self.performStateChange(nextStateValue)
-            interval.end(self.stateName(nextStateValue))
+            interval.end(message: self.tracedStateName(nextStateValue))
         }
         stateTask = task
         
@@ -442,7 +442,7 @@ public extension AsyncStateContainer {
         for syncAction in stateSequence.synchronousStateActions {
             let syncState = syncAction()
             performStateChange(syncState)
-            tracer.emitEvent("StateSequence Changed State", id: sequenceID, stateName(syncState))
+            tracer.emitEvent("StateSequence Changed State", id: sequenceID, message: tracedStateName(syncState))
         }
 
         guard !stateSequence.states.isEmpty else {
@@ -488,7 +488,7 @@ public extension AsyncStateContainer {
                 }
                 self.performStateChange(nextState)
 
-                self.tracer.emitEvent("StateSequence Changed State", id: sequenceID, self.stateName(nextState))
+                self.tracer.emitEvent("StateSequence Changed State", id: sequenceID, message: self.tracedStateName(nextState))
                 iterationCount += 1
             }
         }
@@ -519,7 +519,11 @@ public extension AsyncStateContainer {
             guard let self else { return }
 
             let sequenceID = self.tracer.makeSignpostID()
-            let sequenceInterval = self.tracer.beginInterval("Sequence", id: sequenceID, "\(type(of: sequence)) Sequence")
+            // Resolved eagerly rather than via an `@autoclosure`: the message reads the non-Sendable
+            // `sequence`, and capturing it in a closure handed to the `nonisolated` tracer is the
+            // pattern Swift 6 region isolation rejects. The `isEnabled` check keeps it lazy.
+            let sequenceLabel = self.tracer.isEnabled ? "\(type(of: sequence)) Sequence" : nil
+            let sequenceInterval = self.tracer.beginInterval("Sequence", id: sequenceID, message: sequenceLabel)
             defer { sequenceInterval.end() }
 
             var iterator = sequence.makeAsyncIterator()
@@ -547,7 +551,7 @@ public extension AsyncStateContainer {
                 }
                 self.performStateChange(state)
 
-                self.tracer.emitEvent("Some AsyncSequence Changed State", id: sequenceID, self.stateName(state))
+                self.tracer.emitEvent("Some AsyncSequence Changed State", id: sequenceID, message: self.tracedStateName(state))
                 iterationCount += 1
             }
         }
@@ -618,20 +622,30 @@ private extension AsyncStateContainer {
     // method on both types is a no-op — no message strings are built and no state-name reflection
     // is ever triggered.
     //
-    // Both types are `@MainActor` because nested types do not inherit the enclosing class's global
-    // actor isolation. Without it, the `@autoclosure` message arguments (which capture `self` and
-    // the non-Sendable next state) would be transferred out of the main actor into a `nonisolated`
-    // callee, which region-based isolation rejects with "sending 'self'/'nextState' risks causing
-    // data races". Isolating the tracer to the main actor keeps those closures in the caller's
-    // isolation region while preserving their laziness.
+    // Two message flavors exist deliberately:
+    //
+    // * `@autoclosure () -> String` for messages built from local, `Sendable` values (counts, type
+    //   names, literals). These stay lazy and cost nothing when tracing is off.
+    // * An eager `message: String?` for messages derived from the container's state. Resolving a
+    //   state name requires the main-actor-isolated `self` and a non-Sendable `State`; capturing
+    //   those in an autoclosure makes Swift 6 region isolation treat the closure as leaving the
+    //   main actor ("error: sending 'self' risks causing data races" on Swift 6.2 / Xcode 26.3,
+    //   which is what CI builds with — Swift 6.4 no longer diagnoses it). Passing an already
+    //   resolved `String?` sends nothing but a `Sendable` value. ``tracedStateName(_:)`` keeps
+    //   that path lazy by resolving the name only while tracing is enabled.
 
-    @MainActor
     enum SignpostTracer: Sendable {
         case disabled
         case enabled(OSSignposter)
 
         init(signposter: OSSignposter, enabled: Bool) {
             self = enabled ? .enabled(signposter) : .disabled
+        }
+
+        /// Whether signposts are being emitted. Used to skip resolving eager messages.
+        var isEnabled: Bool {
+            if case .enabled = self { return true }
+            return false
         }
 
         func makeSignpostID() -> OSSignpostID {
@@ -650,14 +664,27 @@ private extension AsyncStateContainer {
             return .active(signposter: sp, name: name, state: sp.beginInterval(name, id: id, "\(text)"))
         }
 
+        /// Begins an interval with an already-resolved message. `nil` begins it without one.
+        func beginInterval(_ name: StaticString, id: OSSignpostID, message: String?) -> SignpostInterval {
+            guard case .enabled(let sp) = self else { return .inactive }
+            guard let message else { return .active(signposter: sp, name: name, state: sp.beginInterval(name, id: id)) }
+            return .active(signposter: sp, name: name, state: sp.beginInterval(name, id: id, "\(message)"))
+        }
+
         func emitEvent(_ name: StaticString, id: OSSignpostID, _ message: @autoclosure () -> String) {
             guard case .enabled(let sp) = self else { return }
             let text = message()
             sp.emitEvent(name, id: id, "\(text)")
         }
+
+        /// Emits an event with an already-resolved message. `nil` emits it without one.
+        func emitEvent(_ name: StaticString, id: OSSignpostID, message: String?) {
+            guard case .enabled(let sp) = self else { return }
+            guard let message else { return sp.emitEvent(name, id: id) }
+            sp.emitEvent(name, id: id, "\(message)")
+        }
     }
 
-    @MainActor
     enum SignpostInterval: Sendable {
         case inactive
         case active(signposter: OSSignposter, name: StaticString, state: OSSignpostIntervalState)
@@ -672,6 +699,13 @@ private extension AsyncStateContainer {
             let text = message()
             sp.endInterval(name, state, "\(text)")
         }
+
+        /// Ends the interval with an already-resolved message. `nil` ends it without one.
+        func end(message: String?) {
+            guard case .active(let sp, let name, let state) = self else { return }
+            guard let message else { return sp.endInterval(name, state) }
+            sp.endInterval(name, state, "\(message)")
+        }
     }
 
     /// A cheap, signpost-friendly name for a state value.
@@ -683,8 +717,8 @@ private extension AsyncStateContainer {
     /// 2. The enum case label via `Mirror`, which does **not** materialize the associated value.
     /// 3. `String(describing:)` fallback — cheap for no-payload enums; other shapes are uncommon.
     ///
-    /// Only called from within `@autoclosure` arguments passed to `SignpostTracer`/`SignpostInterval`,
-    /// which evaluate them only when tracing is `.enabled`/`.active` — costs nothing when tracing is off.
+    /// Only reached through ``tracedStateName(_:)``, which calls it only while tracing is enabled —
+    /// so this costs nothing when tracing is off.
     private func stateName(_ state: State) -> String {
         if let named = state as? CustomStateNameConvertible {
             return named.stateName
@@ -693,6 +727,18 @@ private extension AsyncStateContainer {
             return caseLabel
         }
         return String(describing: state)
+    }
+
+    /// The signpost message for a state change, or `nil` when tracing is disabled.
+    ///
+    /// This is the only way state names reach a signpost. Resolving eagerly (rather than through an
+    /// `@autoclosure`) is deliberate: an autoclosure here would capture the main-actor-isolated
+    /// `self` and a non-Sendable `State`, which Swift 6 region isolation rejects when the closure is
+    /// handed to the `nonisolated` tracer. The `isEnabled` check preserves the laziness that
+    /// mattered — ``stateName(_:)``'s reflection never runs with signposts off.
+    private func tracedStateName(_ state: State) -> String? {
+        guard tracer.isEnabled else { return nil }
+        return stateName(state)
     }
 
     private func performStateChange(_ newState: State) {

--- a/Sources/VSM/AsyncStateContainer.swift
+++ b/Sources/VSM/AsyncStateContainer.swift
@@ -617,7 +617,15 @@ private extension AsyncStateContainer {
     // sites need no per-call guards. When disabled, `beginInterval` returns `.inactive` and every
     // method on both types is a no-op — no message strings are built and no state-name reflection
     // is ever triggered.
+    //
+    // Both types are `@MainActor` because nested types do not inherit the enclosing class's global
+    // actor isolation. Without it, the `@autoclosure` message arguments (which capture `self` and
+    // the non-Sendable next state) would be transferred out of the main actor into a `nonisolated`
+    // callee, which region-based isolation rejects with "sending 'self'/'nextState' risks causing
+    // data races". Isolating the tracer to the main actor keeps those closures in the caller's
+    // isolation region while preserving their laziness.
 
+    @MainActor
     enum SignpostTracer: Sendable {
         case disabled
         case enabled(OSSignposter)
@@ -649,6 +657,7 @@ private extension AsyncStateContainer {
         }
     }
 
+    @MainActor
     enum SignpostInterval: Sendable {
         case inactive
         case active(signposter: OSSignposter, name: StaticString, state: OSSignpostIntervalState)

--- a/Sources/VSM/AsyncStateContainer.swift
+++ b/Sources/VSM/AsyncStateContainer.swift
@@ -215,11 +215,18 @@ public final class AsyncStateContainer<State> {
     @ObservationIgnored
     private let loggingEnabled: Bool
     
-    init(state: State, logger: OSLog, loggingEnabled: Bool = false) {
+    /// When `false` (the default), no signpost intervals or events are emitted and no state-name
+    /// reflection is performed, regardless of whether an Instruments signpost recorder is attached.
+    /// Opt in **per view** (via `@ViewState`/`@RenderedViewState`) only while profiling that view.
+    @ObservationIgnored
+    private let signpostsEnabled: Bool
+    
+    init(state: State, logger: OSLog, loggingEnabled: Bool = false, signpostsEnabled: Bool = false) {
         self.state = state
         self.logger = logger
         self.signposter = OSSignposter(logHandle: logger)
         self.loggingEnabled = loggingEnabled
+        self.signpostsEnabled = signpostsEnabled
     }
     
     deinit {
@@ -231,6 +238,35 @@ public final class AsyncStateContainer<State> {
 
 @available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, visionOS 2.0, macCatalyst 17.0, *)
 extension AsyncStateContainer: Sendable where State: Sendable {}
+
+// MARK: - Custom State Name
+
+/// Provides a cheap, human-readable name for a view state, used in signpost output.
+///
+/// `AsyncStateContainer` labels signposts with the destination state's name. By default it derives
+/// that name via `Mirror` (the enum case label, without reflecting the associated value). Conform
+/// your state to `CustomStateNameConvertible` when you want an O(1), allocation-free name — for
+/// example returning a string literal per case — instead of relying on `Mirror`.
+///
+/// This affects signpost output only; it has no effect when `signpostsEnabled` is `false`, and it
+/// does not change the full-description logging controlled by `loggingEnabled`.
+///
+/// ```swift
+/// extension ExampleViewState: CustomStateNameConvertible {
+///     var stateName: String {
+///         switch self {
+///         case .initialized: "initialized"
+///         case .loading:     "loading"
+///         case .loaded:      "loaded"
+///         case .error:       "error"
+///         }
+///     }
+/// }
+/// ```
+public protocol CustomStateNameConvertible {
+    /// A short, cheap-to-produce name identifying this state (typically the case name).
+    var stateName: String { get }
+}
 
 // MARK: - Core API (always available, no Sendable constraint)
 
@@ -284,11 +320,11 @@ public extension AsyncStateContainer {
         
         let signpostId = signposter.makeSignpostID()
         let postName: StaticString = "State"
-        let state = signposter.beginInterval(postName, id: signpostId)
+        let signpostState = beginInterval(postName, id: signpostId, stateName(nextState))
         
         performStateChange(nextState)
         
-        signposter.endInterval(postName, state)
+        endInterval(postName, signpostState)
     }
     
     // MARK: - Core Async Observe (private — sending)
@@ -305,8 +341,7 @@ public extension AsyncStateContainer {
             
             let signpostId = signposter.makeSignpostID()
             let postName: StaticString = "State"
-            let state = signposter.beginInterval(postName, id: signpostId)
-            defer { signposter.endInterval(postName, state) }
+            let signpostState = beginInterval(postName, id: signpostId)
             
             let nextStateValue = await nextStateClosure()
             
@@ -314,10 +349,12 @@ public extension AsyncStateContainer {
                 if self.loggingEnabled {
                     os_log(.debug, log: self.logger, "observe(async closure) cancelled before state change")
                 }
+                self.endInterval(postName, signpostState)
                 return
             }
             
             self.performStateChange(nextStateValue)
+            self.endInterval(postName, signpostState, self.stateName(nextStateValue))
         }
     }
 
@@ -340,17 +377,18 @@ public extension AsyncStateContainer {
             
             let signpostId = signposter.makeSignpostID()
             let postName: StaticString = "Refresh"
-            let signpostState = signposter.beginInterval(postName, id: signpostId)
-            defer { signposter.endInterval(postName, signpostState) }
+            let signpostState = beginInterval(postName, id: signpostId)
             
             let nextStateValue = await nextStateClosure()
             guard !Task.isCancelled else {
                 if self.loggingEnabled {
                     os_log(.debug, log: self.logger, "refresh(state:) cancelled before state change")
                 }
+                self.endInterval(postName, signpostState)
                 return
             }
             self.performStateChange(nextStateValue)
+            self.endInterval(postName, signpostState, self.stateName(nextStateValue))
         }
         stateTask = task
         
@@ -413,13 +451,13 @@ public extension AsyncStateContainer {
 
         let sequenceID = signposter.makeSignpostID()
         let postName: StaticString = "Sequence"
-        let sequenceState = signposter.beginInterval(postName, id: sequenceID, "State Sequence")
+        let sequenceState = beginInterval(postName, id: sequenceID, "State Sequence")
 
         for syncAction in stateSequence.synchronousStateActions {
             let syncState = syncAction()
             performStateChange(syncState)
             let eventName: StaticString = "StateSequence Changed State"
-            signposter.emitEvent(eventName, id: sequenceID, "State changed to \(String(describing: syncState))")
+            emitEvent(eventName, id: sequenceID, stateName(syncState))
         }
 
         guard !stateSequence.states.isEmpty else {
@@ -428,18 +466,19 @@ public extension AsyncStateContainer {
                 os_log(.debug, log: logger, "StateSequence completed after %d state changes", syncCount)
             }
             let endEventName: StaticString = "State Sequence Ended"
-            signposter.emitEvent(endEventName, id: sequenceID, "Ended after \(syncCount) iterations")
-            signposter.endInterval(postName, sequenceState)
+            emitEvent(endEventName, id: sequenceID, "Ended after \(syncCount) iterations")
+            endInterval(postName, sequenceState)
             return
         }
 
         let asyncStates = stateSequence.states
         stateTask = Task { [weak self, signposter] in
             guard let self else {
-                signposter.endInterval(postName, sequenceState)
+                // Interval token is non-nil only when signposts are enabled; end it without `self`.
+                if let sequenceState { signposter.endInterval(postName, sequenceState) }
                 return
             }
-            defer { signposter.endInterval(postName, sequenceState) }
+            defer { self.endInterval(postName, sequenceState) }
 
             var iterationCount = stateSequence.synchronousStateActions.count + 1
             var remainingIterator = asyncStates.makeIterator()
@@ -450,8 +489,8 @@ public extension AsyncStateContainer {
                         os_log(.debug, log: self.logger, "StateSequence completed after %d state changes", iterationCount - 1)
                     }
                     let eventName: StaticString = "State Sequence Ended"
-                    signposter.emitEvent(eventName, id: sequenceID,
-                                         "Ended after \(iterationCount - 1) iterations")
+                    self.emitEvent(eventName, id: sequenceID,
+                                   "Ended after \(iterationCount - 1) iterations")
                     break
                 }
 
@@ -462,15 +501,14 @@ public extension AsyncStateContainer {
                         os_log(.debug, log: self.logger, "StateSequence cancelled during iteration %d", iterationCount)
                     }
                     let eventName: StaticString = "State Sequence Cancelled"
-                    signposter.emitEvent(eventName, id: sequenceID,
-                                         "Cancelled during iteration \(iterationCount)")
+                    self.emitEvent(eventName, id: sequenceID,
+                                   "Cancelled during iteration \(iterationCount)")
                     break
                 }
-                let nextStateDescription = String(describing: nextState)
                 self.performStateChange(nextState)
 
                 let eventName: StaticString = "StateSequence Changed State"
-                signposter.emitEvent(eventName, id: sequenceID, "State changed to \(nextStateDescription)")
+                self.emitEvent(eventName, id: sequenceID, self.stateName(nextState))
                 iterationCount += 1
             }
         }
@@ -502,8 +540,8 @@ public extension AsyncStateContainer {
             
             let sequenceID = signposter.makeSignpostID()
             let postName: StaticString = "Sequence"
-            let sequenceState = signposter.beginInterval(postName, id: sequenceID, "\(String(describing: sequence.self)) Sequence")
-            defer { signposter.endInterval(postName, sequenceState) }
+            let sequenceState = self.beginInterval(postName, id: sequenceID, "\(type(of: sequence)) Sequence")
+            defer { self.endInterval(postName, sequenceState) }
             
             var iterator = sequence.makeAsyncIterator()
             var iterationCount = 1
@@ -516,8 +554,8 @@ public extension AsyncStateContainer {
                         os_log(.debug, log: self.logger, "AsyncSequence completed after %d state changes", iterationCount - 1)
                     }
                     let eventName: StaticString = "Some AsyncSequence Sequence Ended"
-                    signposter.emitEvent(eventName, id: sequenceID,
-                                         "Ended after \(iterationCount - 1) iterations")
+                    self.emitEvent(eventName, id: sequenceID,
+                                   "Ended after \(iterationCount - 1) iterations")
                     break
                 }
                 
@@ -526,14 +564,14 @@ public extension AsyncStateContainer {
                         os_log(.debug, log: self.logger, "AsyncSequence cancelled during iteration %d", iterationCount)
                     }
                     let eventName: StaticString = "Some AsyncSequence Sequence Cancelled"
-                    signposter.emitEvent(eventName, id: sequenceID,
-                                         "Cancelled during iteration \(iterationCount)")
+                    self.emitEvent(eventName, id: sequenceID,
+                                   "Cancelled during iteration \(iterationCount)")
                     break
                 }
                 self.performStateChange(state)
                 
                 let eventName: StaticString = "Some AsyncSequence Changed State"
-                signposter.emitEvent(eventName, id: sequenceID, "State changed to \(String(describing: state))")
+                self.emitEvent(eventName, id: sequenceID, self.stateName(state))
                 iterationCount += 1
             }
         }
@@ -599,6 +637,61 @@ private extension AsyncStateContainer {
 
 
     
+    // MARK: - Signpost helpers (gated by signpostsEnabled)
+    //
+    // Every signpost emission and every state-name computation is routed through these helpers so
+    // that with `signpostsEnabled == false` (the default) nothing is emitted and, crucially, no
+    // message strings are ever built. `beginInterval` returns `nil` when disabled; `endInterval`
+    // no-ops on a `nil` token, so interval bracketing stays balanced without per-call-site guards.
+
+    private func beginInterval(_ name: StaticString, id: OSSignpostID) -> OSSignpostIntervalState? {
+        guard signpostsEnabled else { return nil }
+        return signposter.beginInterval(name, id: id)
+    }
+
+    private func beginInterval(_ name: StaticString, id: OSSignpostID, _ message: @autoclosure () -> String) -> OSSignpostIntervalState? {
+        guard signpostsEnabled else { return nil }
+        let text = message()
+        return signposter.beginInterval(name, id: id, "\(text)")
+    }
+
+    private func endInterval(_ name: StaticString, _ state: OSSignpostIntervalState?) {
+        guard let state else { return }
+        signposter.endInterval(name, state)
+    }
+
+    private func endInterval(_ name: StaticString, _ state: OSSignpostIntervalState?, _ message: @autoclosure () -> String) {
+        guard let state else { return }
+        let text = message()
+        signposter.endInterval(name, state, "\(text)")
+    }
+
+    private func emitEvent(_ name: StaticString, id: OSSignpostID, _ message: @autoclosure () -> String) {
+        guard signpostsEnabled else { return }
+        let text = message()
+        signposter.emitEvent(name, id: id, "\(text)")
+    }
+
+    /// A cheap, signpost-friendly name for a state value.
+    ///
+    /// Deliberately avoids `String(describing:)`, which recursively reflects a value's entire
+    /// payload (arrays, nested optionals, etc.) — the dominant reflection cost this type used to
+    /// pay on every transition. Resolution order:
+    /// 1. ``CustomStateNameConvertible`` if the state conforms — O(1), author-provided.
+    /// 2. The enum case label via `Mirror`, which does **not** materialize the associated value.
+    /// 3. `String(describing:)` fallback — cheap for no-payload enums; other shapes are uncommon.
+    ///
+    /// Only called from within `signpostsEnabled` guards, so it costs nothing when signposts are off.
+    private func stateName(_ state: State) -> String {
+        if let named = state as? CustomStateNameConvertible {
+            return named.stateName
+        }
+        if let caseLabel = Mirror(reflecting: state).children.first?.label {
+            return caseLabel
+        }
+        return String(describing: state)
+    }
+
     private func performStateChange(_ newState: State) {
         if loggingEnabled {
             os_log(.info, log: logger, "State changed to: %{public}@", String(describing: newState))

--- a/Sources/VSM/AsyncStateContainer.swift
+++ b/Sources/VSM/AsyncStateContainer.swift
@@ -210,23 +210,16 @@ public final class AsyncStateContainer<State> {
     private let logger: OSLog
     
     @ObservationIgnored
-    private let signposter: OSSignposter
-    
-    @ObservationIgnored
     private let loggingEnabled: Bool
-    
-    /// When `false` (the default), no signpost intervals or events are emitted and no state-name
-    /// reflection is performed, regardless of whether an Instruments signpost recorder is attached.
-    /// Opt in **per view** (via `@ViewState`/`@RenderedViewState`) only while profiling that view.
+
     @ObservationIgnored
-    private let signpostsEnabled: Bool
-    
+    private let tracer: SignpostTracer
+
     init(state: State, logger: OSLog, loggingEnabled: Bool = false, signpostsEnabled: Bool = false) {
         self.state = state
         self.logger = logger
-        self.signposter = OSSignposter(logHandle: logger)
         self.loggingEnabled = loggingEnabled
-        self.signpostsEnabled = signpostsEnabled
+        self.tracer = SignpostTracer(signposter: OSSignposter(logHandle: logger), enabled: signpostsEnabled)
     }
     
     deinit {
@@ -317,14 +310,12 @@ public extension AsyncStateContainer {
         }
         
         cancelRunningObservations()
-        
-        let signpostId = signposter.makeSignpostID()
-        let postName: StaticString = "State"
-        let signpostState = beginInterval(postName, id: signpostId, stateName(nextState))
-        
+
+        let interval = tracer.beginInterval("State", id: tracer.makeSignpostID(), stateName(nextState))
+
         performStateChange(nextState)
-        
-        endInterval(postName, signpostState)
+
+        interval.end()
     }
     
     // MARK: - Core Async Observe (private — sending)
@@ -338,23 +329,21 @@ public extension AsyncStateContainer {
         
         stateTask = Task { @MainActor [weak self] in
             guard let self else { return }
-            
-            let signpostId = signposter.makeSignpostID()
-            let postName: StaticString = "State"
-            let signpostState = beginInterval(postName, id: signpostId)
-            
+
+            let interval = self.tracer.beginInterval("State", id: self.tracer.makeSignpostID())
+
             let nextStateValue = await nextStateClosure()
-            
+
             guard !Task.isCancelled else {
                 if self.loggingEnabled {
                     os_log(.debug, log: self.logger, "observe(async closure) cancelled before state change")
                 }
-                self.endInterval(postName, signpostState)
+                interval.end()
                 return
             }
-            
+
             self.performStateChange(nextStateValue)
-            self.endInterval(postName, signpostState, self.stateName(nextStateValue))
+            interval.end(self.stateName(nextStateValue))
         }
     }
 
@@ -374,21 +363,19 @@ public extension AsyncStateContainer {
         
         let task = Task { @MainActor [weak self] in
             guard let self else { return }
-            
-            let signpostId = signposter.makeSignpostID()
-            let postName: StaticString = "Refresh"
-            let signpostState = beginInterval(postName, id: signpostId)
-            
+
+            let interval = self.tracer.beginInterval("Refresh", id: self.tracer.makeSignpostID())
+
             let nextStateValue = await nextStateClosure()
             guard !Task.isCancelled else {
                 if self.loggingEnabled {
                     os_log(.debug, log: self.logger, "refresh(state:) cancelled before state change")
                 }
-                self.endInterval(postName, signpostState)
+                interval.end()
                 return
             }
             self.performStateChange(nextStateValue)
-            self.endInterval(postName, signpostState, self.stateName(nextStateValue))
+            interval.end(self.stateName(nextStateValue))
         }
         stateTask = task
         
@@ -449,15 +436,13 @@ public extension AsyncStateContainer {
         
         cancelRunningObservations()
 
-        let sequenceID = signposter.makeSignpostID()
-        let postName: StaticString = "Sequence"
-        let sequenceState = beginInterval(postName, id: sequenceID, "State Sequence")
+        let sequenceID = tracer.makeSignpostID()
+        let sequenceInterval = tracer.beginInterval("Sequence", id: sequenceID, "State Sequence")
 
         for syncAction in stateSequence.synchronousStateActions {
             let syncState = syncAction()
             performStateChange(syncState)
-            let eventName: StaticString = "StateSequence Changed State"
-            emitEvent(eventName, id: sequenceID, stateName(syncState))
+            tracer.emitEvent("StateSequence Changed State", id: sequenceID, stateName(syncState))
         }
 
         guard !stateSequence.states.isEmpty else {
@@ -465,20 +450,18 @@ public extension AsyncStateContainer {
             if loggingEnabled {
                 os_log(.debug, log: logger, "StateSequence completed after %d state changes", syncCount)
             }
-            let endEventName: StaticString = "State Sequence Ended"
-            emitEvent(endEventName, id: sequenceID, "Ended after \(syncCount) iterations")
-            endInterval(postName, sequenceState)
+            tracer.emitEvent("State Sequence Ended", id: sequenceID, "Ended after \(syncCount) iterations")
+            sequenceInterval.end()
             return
         }
 
         let asyncStates = stateSequence.states
-        stateTask = Task { [weak self, signposter] in
+        stateTask = Task { [weak self] in
             guard let self else {
-                // Interval token is non-nil only when signposts are enabled; end it without `self`.
-                if let sequenceState { signposter.endInterval(postName, sequenceState) }
+                sequenceInterval.end()
                 return
             }
-            defer { self.endInterval(postName, sequenceState) }
+            defer { sequenceInterval.end() }
 
             var iterationCount = stateSequence.synchronousStateActions.count + 1
             var remainingIterator = asyncStates.makeIterator()
@@ -488,9 +471,8 @@ public extension AsyncStateContainer {
                     if self.loggingEnabled {
                         os_log(.debug, log: self.logger, "StateSequence completed after %d state changes", iterationCount - 1)
                     }
-                    let eventName: StaticString = "State Sequence Ended"
-                    self.emitEvent(eventName, id: sequenceID,
-                                   "Ended after \(iterationCount - 1) iterations")
+                    self.tracer.emitEvent("State Sequence Ended", id: sequenceID,
+                                          "Ended after \(iterationCount - 1) iterations")
                     break
                 }
 
@@ -500,15 +482,13 @@ public extension AsyncStateContainer {
                     if self.loggingEnabled {
                         os_log(.debug, log: self.logger, "StateSequence cancelled during iteration %d", iterationCount)
                     }
-                    let eventName: StaticString = "State Sequence Cancelled"
-                    self.emitEvent(eventName, id: sequenceID,
-                                   "Cancelled during iteration \(iterationCount)")
+                    self.tracer.emitEvent("State Sequence Cancelled", id: sequenceID,
+                                          "Cancelled during iteration \(iterationCount)")
                     break
                 }
                 self.performStateChange(nextState)
 
-                let eventName: StaticString = "StateSequence Changed State"
-                self.emitEvent(eventName, id: sequenceID, self.stateName(nextState))
+                self.tracer.emitEvent("StateSequence Changed State", id: sequenceID, self.stateName(nextState))
                 iterationCount += 1
             }
         }
@@ -537,41 +517,37 @@ public extension AsyncStateContainer {
         
         stateTask = Task { @MainActor [weak self] in
             guard let self else { return }
-            
-            let sequenceID = signposter.makeSignpostID()
-            let postName: StaticString = "Sequence"
-            let sequenceState = self.beginInterval(postName, id: sequenceID, "\(type(of: sequence)) Sequence")
-            defer { self.endInterval(postName, sequenceState) }
-            
+
+            let sequenceID = self.tracer.makeSignpostID()
+            let sequenceInterval = self.tracer.beginInterval("Sequence", id: sequenceID, "\(type(of: sequence)) Sequence")
+            defer { sequenceInterval.end() }
+
             var iterator = sequence.makeAsyncIterator()
             var iterationCount = 1
-            
+
             while !Task.isCancelled {
                 let nextState = await iterator.next(isolation: #isolation)
-                
+
                 guard let state = nextState else {
                     if self.loggingEnabled {
                         os_log(.debug, log: self.logger, "AsyncSequence completed after %d state changes", iterationCount - 1)
                     }
-                    let eventName: StaticString = "Some AsyncSequence Sequence Ended"
-                    self.emitEvent(eventName, id: sequenceID,
-                                   "Ended after \(iterationCount - 1) iterations")
+                    self.tracer.emitEvent("Some AsyncSequence Sequence Ended", id: sequenceID,
+                                          "Ended after \(iterationCount - 1) iterations")
                     break
                 }
-                
+
                 guard !Task.isCancelled else {
                     if self.loggingEnabled {
                         os_log(.debug, log: self.logger, "AsyncSequence cancelled during iteration %d", iterationCount)
                     }
-                    let eventName: StaticString = "Some AsyncSequence Sequence Cancelled"
-                    self.emitEvent(eventName, id: sequenceID,
-                                   "Cancelled during iteration \(iterationCount)")
+                    self.tracer.emitEvent("Some AsyncSequence Sequence Cancelled", id: sequenceID,
+                                          "Cancelled during iteration \(iterationCount)")
                     break
                 }
                 self.performStateChange(state)
-                
-                let eventName: StaticString = "Some AsyncSequence Changed State"
-                self.emitEvent(eventName, id: sequenceID, self.stateName(state))
+
+                self.tracer.emitEvent("Some AsyncSequence Changed State", id: sequenceID, self.stateName(state))
                 iterationCount += 1
             }
         }
@@ -635,41 +611,58 @@ private extension AsyncStateContainer {
         stateTask = nil
     }
 
-
-    
-    // MARK: - Signpost helpers (gated by signpostsEnabled)
+    // MARK: - Signpost tracing types
     //
-    // Every signpost emission and every state-name computation is routed through these helpers so
-    // that with `signpostsEnabled == false` (the default) nothing is emitted and, crucially, no
-    // message strings are ever built. `beginInterval` returns `nil` when disabled; `endInterval`
-    // no-ops on a `nil` token, so interval bracketing stays balanced without per-call-site guards.
+    // `SignpostTracer` and `SignpostInterval` encapsulate the enabled/disabled distinction so call
+    // sites need no per-call guards. When disabled, `beginInterval` returns `.inactive` and every
+    // method on both types is a no-op — no message strings are built and no state-name reflection
+    // is ever triggered.
 
-    private func beginInterval(_ name: StaticString, id: OSSignpostID) -> OSSignpostIntervalState? {
-        guard signpostsEnabled else { return nil }
-        return signposter.beginInterval(name, id: id)
+    enum SignpostTracer: Sendable {
+        case disabled
+        case enabled(OSSignposter)
+
+        init(signposter: OSSignposter, enabled: Bool) {
+            self = enabled ? .enabled(signposter) : .disabled
+        }
+
+        func makeSignpostID() -> OSSignpostID {
+            guard case .enabled(let sp) = self else { return .invalid }
+            return sp.makeSignpostID()
+        }
+
+        func beginInterval(_ name: StaticString, id: OSSignpostID) -> SignpostInterval {
+            guard case .enabled(let sp) = self else { return .inactive }
+            return .active(signposter: sp, name: name, state: sp.beginInterval(name, id: id))
+        }
+
+        func beginInterval(_ name: StaticString, id: OSSignpostID, _ message: @autoclosure () -> String) -> SignpostInterval {
+            guard case .enabled(let sp) = self else { return .inactive }
+            let text = message()
+            return .active(signposter: sp, name: name, state: sp.beginInterval(name, id: id, "\(text)"))
+        }
+
+        func emitEvent(_ name: StaticString, id: OSSignpostID, _ message: @autoclosure () -> String) {
+            guard case .enabled(let sp) = self else { return }
+            let text = message()
+            sp.emitEvent(name, id: id, "\(text)")
+        }
     }
 
-    private func beginInterval(_ name: StaticString, id: OSSignpostID, _ message: @autoclosure () -> String) -> OSSignpostIntervalState? {
-        guard signpostsEnabled else { return nil }
-        let text = message()
-        return signposter.beginInterval(name, id: id, "\(text)")
-    }
+    enum SignpostInterval: Sendable {
+        case inactive
+        case active(signposter: OSSignposter, name: StaticString, state: OSSignpostIntervalState)
 
-    private func endInterval(_ name: StaticString, _ state: OSSignpostIntervalState?) {
-        guard let state else { return }
-        signposter.endInterval(name, state)
-    }
+        func end() {
+            guard case .active(let sp, let name, let state) = self else { return }
+            sp.endInterval(name, state)
+        }
 
-    private func endInterval(_ name: StaticString, _ state: OSSignpostIntervalState?, _ message: @autoclosure () -> String) {
-        guard let state else { return }
-        let text = message()
-        signposter.endInterval(name, state, "\(text)")
-    }
-
-    private func emitEvent(_ name: StaticString, id: OSSignpostID, _ message: @autoclosure () -> String) {
-        guard signpostsEnabled else { return }
-        let text = message()
-        signposter.emitEvent(name, id: id, "\(text)")
+        func end(_ message: @autoclosure () -> String) {
+            guard case .active(let sp, let name, let state) = self else { return }
+            let text = message()
+            sp.endInterval(name, state, "\(text)")
+        }
     }
 
     /// A cheap, signpost-friendly name for a state value.
@@ -681,7 +674,8 @@ private extension AsyncStateContainer {
     /// 2. The enum case label via `Mirror`, which does **not** materialize the associated value.
     /// 3. `String(describing:)` fallback — cheap for no-payload enums; other shapes are uncommon.
     ///
-    /// Only called from within `signpostsEnabled` guards, so it costs nothing when signposts are off.
+    /// Only called from within `@autoclosure` arguments passed to `SignpostTracer`/`SignpostInterval`,
+    /// which evaluate them only when tracing is `.enabled`/`.active` — costs nothing when tracing is off.
     private func stateName(_ state: State) -> String {
         if let named = state as? CustomStateNameConvertible {
             return named.stateName

--- a/Sources/VSM/Documentation.docc/Reference/Debugging.md
+++ b/Sources/VSM/Documentation.docc/Reference/Debugging.md
@@ -97,7 +97,7 @@ This makes it easy to answer questions like: "Did a state change cause a surge o
 
 ### Enabling Signposts Per View
 
-Signposts are **opt in on a per-view basis** and disabled by default. When disabled, `AsyncStateContainer` makes no signpost calls and performs no state-name reflection at all — there is zero cost whether or not Instruments is attached. Turn them on only for the specific view you are profiling by passing `signpostsEnabled: true`:
+Signposts are **opt in on a per-view basis** and disabled by default. When disabled, `AsyncStateContainer` makes no signpost calls and performs no state-name reflection at all. When enabled, they cost roughly 2.7 µs per state change *whether or not Instruments is recording* — see <doc:Debugging#What-Logging-and-Signposts-Cost> before you leave this switch on. Turn them on only for the specific view you are profiling by passing `signpostsEnabled: true`:
 
 ```swift
 struct ProductDetailView: View {
@@ -141,7 +141,7 @@ Each call to `observe()` on a state container produces a signpost interval. The 
 
 To keep signpost output cheap and readable, each interval and event is labelled with the **name of the destination state only** — for an enum state, its case name — rather than a full description of the state value. Producing a full description would recursively reflect the entire state (associated values, nested collections, and so on), which is exactly the kind of work you do not want to introduce into a profiling session. When you need the full value while debugging, use Console logging (`loggingEnabled`), which is where the complete description belongs.
 
-The state name is derived automatically via `Mirror`. If you want an allocation-free, O(1) name — or a custom label per case — conform your state to ``CustomStateNameConvertible``:
+The state name is derived automatically via `Mirror`, which costs roughly 840 ns per state change. Conforming your state to ``CustomStateNameConvertible`` gives you an allocation-free, O(1) name instead — about 20 ns, or roughly a fortieth of the reflected cost — and it halves the total per-transition cost of having signposts enabled. It also lets you choose a custom label per case:
 
 ```swift
 extension ProductDetailViewState: CustomStateNameConvertible {
@@ -166,3 +166,34 @@ The signpost lane name is derived from the same `subsystem` and `observedViewTyp
 ![An example of VSM signpost intervals in Instruments, showing per-view state change lanes on the os_signpost timeline](ExampleInstruments)
 
 > Important: Be deliberate about which instruments you record alongside signposts. The **SwiftUI** instrument adds a profiler-only overhead to every observable state change that can distort a trace. See <doc:Profiling> for how to choose an instrument configuration that reflects production.
+
+## What Logging and Signposts Cost
+
+Both tools are opt in per view because both are expensive enough to change how your app behaves. **Enable them while you are actively debugging a view or recording a trace of it, and turn them off when you are done.** Neither belongs in code you ship.
+
+The figures below are per state change, measured on an Apple Silicon Mac with an optimized build, against a state enum whose associated value carries a 200-element array. Treat them as orders of magnitude rather than exact numbers — the Console logging figure in particular scales with the size of your state's payload.
+
+| Configuration | Cost per state change |
+|---|---|
+| Both disabled — the default | a few dozen nanoseconds |
+| `signpostsEnabled: true`, state name resolved by `Mirror` | ~2.7 µs |
+| `signpostsEnabled: true`, state conforms to ``CustomStateNameConvertible`` | ~1.3 µs |
+| `loggingEnabled: true` | ~680 µs |
+
+If you are investigating a performance problem around state changes, check these two switches first — a forgotten `loggingEnabled: true` is enough on its own to make a rapidly updating view hitch visibly.
+
+### Signposts Cost the Same Whether or Not Instruments Is Recording
+
+It is natural to assume signposts are free unless a trace is being recorded. They are not. `signpostsEnabled: true` is the only gate: with it on, the container resolves a state name and issues `os_signpost` calls on every transition, whether or not Instruments is attached. The signpost calls alone account for roughly a microsecond per state change with nothing recording, because signposts are delivered to the unified logging system rather than to Instruments directly.
+
+There is also no way to detect a recording session and gate on it — `OSLog.signpostsEnabled` and `OSSignposter.isEnabled` both report `true` on a device with nothing attached. So a `signpostsEnabled: true` that survives code review costs your users the full ~2.7 µs on every state change of that view, in Debug and Release alike. Treat it like a breakpoint, not like a build setting.
+
+### Console Logging Reflects the Entire State
+
+`loggingEnabled: true` logs a full description of each new state, which recursively reflects the whole value — every associated value, nested collection, and element. That is what makes it useful when you need to see exactly what your state contains, and it is also what makes it by far the most expensive option here: roughly 680 µs per state change for the state described above, growing with the payload.
+
+When you want to watch transitions without that cost, use signposts instead. They record the destination state's name only, which is why they are three orders of magnitude cheaper.
+
+### With Both Disabled, the Cost Is Small but Not Zero
+
+With the defaults in place, a state change still passes through the container's disabled tracing checks, which cost a few dozen nanoseconds. No reflection runs, no message strings are built, and no signpost or log calls are made. This is small enough to ignore in any realistic view, but it is not literally nothing.

--- a/Sources/VSM/Documentation.docc/Reference/Debugging.md
+++ b/Sources/VSM/Documentation.docc/Reference/Debugging.md
@@ -91,9 +91,39 @@ The type name becomes the `category` of the underlying `OSLog`. Xcode's Console 
 
 ## Instruments: Visualizing State Changes with OS Signposts
 
-In addition to Console logging, `AsyncStateContainer` emits **OS signposts** for every state transition. Signposts are always active, regardless of the `loggingEnabled` flag, and they let you visualize state machine activity on a precise timeline in Instruments alongside other instruments such as the SwiftUI instrument.
+In addition to Console logging, `AsyncStateContainer` can emit **OS signposts** for every state transition, letting you visualize state machine activity on a precise timeline in Instruments alongside other instruments such as the SwiftUI instrument.
 
 This makes it easy to answer questions like: "Did a state change cause a surge of SwiftUI body re-evaluations?" or "How long did the app spend in the loading state?"
+
+### Enabling Signposts Per View
+
+Signposts are **opt in on a per-view basis** and disabled by default. When disabled, `AsyncStateContainer` makes no signpost calls and performs no state-name reflection at all — there is zero cost whether or not Instruments is attached. Turn them on only for the specific view you are profiling by passing `signpostsEnabled: true`:
+
+```swift
+struct ProductDetailView: View {
+    @ViewState(
+        subsystem: "com.myapp.vsm",
+        observedViewType: ProductDetailView.self,
+        signpostsEnabled: true
+    )
+    var state: ProductDetailViewState = .initialized(.init())
+}
+```
+
+For a UIKit view controller using `@RenderedViewState`:
+
+```swift
+class ProductDetailViewController: UIViewController {
+    @RenderedViewState(render: ProductDetailViewController.render, signpostsEnabled: true)
+    var state: ProductDetailViewState = .initialized(.init())
+
+    func render() {
+        // ...
+    }
+}
+```
+
+`signpostsEnabled` and `loggingEnabled` are independent — enable either without the other.
 
 ### Adding the os_signpost Instrument
 
@@ -103,29 +133,36 @@ The os_signpost instrument is not included in any of Instruments' built-in templ
 2. Choose any template to start — **Blank** is the cleanest option if you plan to build your own instrument set.
 3. Click the **+** button in the instrument library (top-right area of the Instruments toolbar) to open the instrument picker.
 4. Search for **"os_signpost"** and double-click it to add it to your trace document.
-5. Profile your app. VSM signpost intervals will appear in the os_signpost track as labelled intervals.
+5. Profile your app. Provided the view you are exercising was configured with `signpostsEnabled: true`, its VSM signpost intervals will appear in the os_signpost track as labelled intervals.
 
 ### Reading the Signpost Lanes
 
 Each call to `observe()` on a state container produces a signpost interval. The interval begins when the observation starts and ends when the resulting state change is applied. For `StateSequence` observations, a single interval spans the entire sequence, with individual state changes marked as events within it.
+
+To keep signpost output cheap and readable, each interval and event is labelled with the **name of the destination state only** — for an enum state, its case name — rather than a full description of the state value. Producing a full description would recursively reflect the entire state (associated values, nested collections, and so on), which is exactly the kind of work you do not want to introduce into a profiling session. When you need the full value while debugging, use Console logging (`loggingEnabled`), which is where the complete description belongs.
+
+The state name is derived automatically via `Mirror`. If you want an allocation-free, O(1) name — or a custom label per case — conform your state to ``CustomStateNameConvertible``:
+
+```swift
+extension ProductDetailViewState: CustomStateNameConvertible {
+    var stateName: String {
+        switch self {
+        case .initialized: "initialized"
+        case .loading:     "loading"
+        case .loaded:      "loaded"
+        case .error:       "error"
+        }
+    }
+}
+```
 
 The signpost lane name is derived from the same `subsystem` and `observedViewType` values passed to the property wrapper:
 
 - If you use the defaults, all state changes across every view land in a single lane named `"com.wayfair.vsm"` under the `"VSM View"` category. This can become crowded quickly in an app with many VSM views.
 - If you provide a `subsystem` and `observedViewType`, each view gets its own clearly labelled lane, making it straightforward to correlate a specific view's state changes with other timeline data.
 
-For best results in Instruments, configure each view that you are profiling with both parameters:
-
-```swift
-struct ProductDetailView: View {
-    @ViewState(
-        subsystem: "com.myapp.vsm",
-        observedViewType: ProductDetailView.self
-    )
-    var state: ProductDetailViewState = .initialized(.init())
-}
-```
-
 ![An example of VSM signpost intervals in Instruments, showing per-view state change lanes on the os_signpost timeline](ExampleInstruments)
 
-> Tip: You do not need to enable `loggingEnabled` to get signpost data in Instruments. Signpost calls are always made by `AsyncStateContainer`, but the OS discards them at negligible cost unless Instruments is actively recording a trace. There is no special build configuration required — you can profile a Debug build directly from Xcode using **Product > Profile** (`⌘I`).
+> Tip: `signpostsEnabled` and `loggingEnabled` are separate. You do not need Console logging to get signpost data, and enabling signposts does not add Console output. There is no special build configuration required — you can profile a Debug build directly from Xcode using **Product > Profile** (`⌘I`).
+
+> Important: Be deliberate about which instruments you record alongside signposts. The **SwiftUI** instrument adds a profiler-only overhead to every observable state change that can distort a trace. See <doc:Profiling> for how to choose an instrument configuration that reflects production.

--- a/Sources/VSM/Documentation.docc/Reference/Debugging.md
+++ b/Sources/VSM/Documentation.docc/Reference/Debugging.md
@@ -161,8 +161,8 @@ The signpost lane name is derived from the same `subsystem` and `observedViewTyp
 - If you use the defaults, all state changes across every view land in a single lane named `"com.wayfair.vsm"` under the `"VSM View"` category. This can become crowded quickly in an app with many VSM views.
 - If you provide a `subsystem` and `observedViewType`, each view gets its own clearly labelled lane, making it straightforward to correlate a specific view's state changes with other timeline data.
 
-![An example of VSM signpost intervals in Instruments, showing per-view state change lanes on the os_signpost timeline](ExampleInstruments)
-
 > Tip: `signpostsEnabled` and `loggingEnabled` are separate. You do not need Console logging to get signpost data, and enabling signposts does not add Console output. There is no special build configuration required — you can profile a Debug build directly from Xcode using **Product > Profile** (`⌘I`).
+
+![An example of VSM signpost intervals in Instruments, showing per-view state change lanes on the os_signpost timeline](ExampleInstruments)
 
 > Important: Be deliberate about which instruments you record alongside signposts. The **SwiftUI** instrument adds a profiler-only overhead to every observable state change that can distort a trace. See <doc:Profiling> for how to choose an instrument configuration that reflects production.

--- a/Sources/VSM/Documentation.docc/Reference/Profiling.md
+++ b/Sources/VSM/Documentation.docc/Reference/Profiling.md
@@ -14,7 +14,7 @@ When the SwiftUI instrument records, AttributeGraph runs in trace-recording mode
 
 In a trace, the cost appears as time attributed to a stack similar to:
 
-```
+```text
 AsyncStateContainer.state.setter
  → ObservationRegistrar … withMutation
    → AGGraphAddTraceEvent

--- a/Sources/VSM/Documentation.docc/Reference/Profiling.md
+++ b/Sources/VSM/Documentation.docc/Reference/Profiling.md
@@ -25,6 +25,17 @@ This is not specific to VSM — any `@Observable` type mutated frequently under 
 
 > Important: This cost is present **only while the SwiftUI instrument is recording**. It is zero in a normal Debug or Release build. Do not try to "optimize" it away by reverting to `ObservableObject` — that trades a profiler-only artifact for real, per-mutation overhead in your shipping app.
 
+## When State Changes Themselves Look Expensive
+
+The SwiftUI instrument is not the only reason state changes can look costly. Before concluding that VSM's state handling is slow, rule out VSM's own debugging switches — both are per-view opt ins that are easy to enable during an investigation and forget:
+
+- **`loggingEnabled: true`** logs a full description of every new state, recursively reflecting the entire value. Roughly 680 µs per state change for a state carrying a 200-element array, and it grows with the payload. This is the single most likely cause of a state-change hotspot that reproduces outside the profiler.
+- **`signpostsEnabled: true`** resolves a state name and emits signposts on every transition — roughly 2.7 µs per state change, or ~1.3 µs if the state conforms to ``CustomStateNameConvertible``.
+
+Unlike the SwiftUI instrument's overhead, neither of these is a profiler artifact. **Both cost the same in a normal Debug or Release build as they do under Instruments**, because signposts go to the unified logging system and are not gated on a trace being recorded. If either switch reaches production, so does its cost. Enable them only while you are actively debugging or recording the view in question.
+
+See <doc:Debugging#What-Logging-and-Signposts-Cost> for the full breakdown. If you need signposts during the trace you are recording, conforming your state to ``CustomStateNameConvertible`` roughly halves what they cost.
+
 ## Recommended Instrument Configurations
 
 Pick the instrument set based on the question you are answering:

--- a/Sources/VSM/Documentation.docc/Reference/Profiling.md
+++ b/Sources/VSM/Documentation.docc/Reference/Profiling.md
@@ -1,0 +1,44 @@
+# Profiling VSM Apps
+
+Choose an Instruments configuration whose measurements reflect production, not the profiler.
+
+## Overview
+
+VSM drives all of a view's state through a single `@Observable` property on ``AsyncStateContainer``, which SwiftUI observes to re-render. This is the correct, modern choice: `@Observable` provides per-property change tracking and avoids the `objectWillChange` bookkeeping of the older `ObservableObject` pattern, so it is cheaper in a shipping app.
+
+There is one thing to be aware of when profiling, however. The **SwiftUI instrument** — the "SwiftUI" template and the View Body / AttributeGraph tracks it enables — adds measurable overhead to every observable state mutation *while it is recording*. That overhead does not exist in normal builds; it is a profiler observer effect. But it can distort a trace enough to send you chasing a cost that isn't real.
+
+## Why the SwiftUI Instrument Inflates State Changes
+
+When the SwiftUI instrument records, AttributeGraph runs in trace-recording mode and emits a trace event for every observed change. To label each event it resolves the changed property's key path name, which the Swift runtime looks up by symbolicating the key path (`dladdr` against the Mach-O symbol table). That symbolication is not cached, so it repeats on every mutation.
+
+In a trace, the cost appears as time attributed to a stack similar to:
+
+```
+AsyncStateContainer.state.setter
+ → ObservationRegistrar … withMutation
+   → AGGraphAddTraceEvent
+     → AnyKeyPath.debugDescription → swift_keyPath_copySymbolName → dladdr
+```
+
+This is not specific to VSM — any `@Observable` type mutated frequently under the SwiftUI instrument pays it. VSM simply concentrates it: because every transition in a feature flows through one observable property, a burst of transitions (pagination, streaming updates, rapid refreshes) surfaces the cost as a hotspot rather than spreading it thinly.
+
+> Important: This cost is present **only while the SwiftUI instrument is recording**. It is zero in a normal Debug or Release build. Do not try to "optimize" it away by reverting to `ObservableObject` — that trades a profiler-only artifact for real, per-mutation overhead in your shipping app.
+
+## Recommended Instrument Configurations
+
+Pick the instrument set based on the question you are answering:
+
+| Question | Use |
+|---|---|
+| Scrolling smoothness, hitches, hangs, frame timing | The **Animation Hitches** template (optionally with **Time Profiler**). It does not enable AttributeGraph tracing, so state-mutation cost is not inflated. |
+| CPU cost of your own code during a flow | **Time Profiler**, optionally with the **os_signpost** instrument to bracket VSM transitions (see <doc:Debugging>). |
+| "Which view bodies re-evaluate, and how often?" | The **SwiftUI** template — accept the observer effect on state mutations as the price of that visibility, and read any state-mutation cost with skepticism. |
+
+For representative hitch and timing numbers on a VSM app, prefer the first two rows. Reserve the SwiftUI template for structural body-evaluation questions, and cross-check any suspicious state-mutation cost against a run recorded without it.
+
+## See Also
+
+- <doc:Debugging>
+- ``CustomStateNameConvertible``
+- ``AsyncStateContainer``

--- a/Sources/VSM/Documentation.docc/VSM.md
+++ b/Sources/VSM/Documentation.docc/VSM.md
@@ -26,6 +26,7 @@ This package provides helpful types for implementing VSM, such as the ``ViewStat
 - <doc:Navigation>
 - <doc:ViewStateExtensions>
 - <doc:Debugging>
+- <doc:Profiling>
 
 ### VSM Guide Articles
 

--- a/Sources/VSM/RenderedViewState.swift
+++ b/Sources/VSM/RenderedViewState.swift
@@ -144,12 +144,14 @@ public struct RenderedViewState<State> {
     ///   - wrappedValue: The view state to be managed by the state container.
     ///   - render: The function to call when the view state _did change_.
     ///   - subsystem: The subsystem identifier for logging (defaults to "com.wayfair.vsm").
-    ///   - loggingEnabled: When `true`, enables debug logging of state changes to the Console. Defaults to `false`.
+    ///   - loggingEnabled: When `true`, enables debug logging of state changes (full description) to the Console. Defaults to `false`.
+    ///   - signpostsEnabled: When `true`, emits Instruments signposts (state name only) for this view's transitions. Opt in per view while profiling; defaults to `false` so no signpost work or state-name reflection occurs otherwise.
     public init<Parent>(
         wrappedValue: State,
         render: @escaping (Parent) -> () -> (),
         subsystem: String = "com.wayfair.vsm",
-        loggingEnabled: Bool = false
+        loggingEnabled: Bool = false,
+        signpostsEnabled: Bool = false
     )
     where Parent: AnyObject {
         let observedViewType = String(describing: Parent.self)
@@ -162,7 +164,8 @@ public struct RenderedViewState<State> {
             container: AsyncStateContainer(
                 state: wrappedValue,
                 logger: OSLog(subsystem: subsystem, category: observedViewType),
-                loggingEnabled: loggingEnabled
+                loggingEnabled: loggingEnabled,
+                signpostsEnabled: signpostsEnabled
             ),
             render: anyRender
         )
@@ -172,7 +175,8 @@ public struct RenderedViewState<State> {
         wrappedValue: State,
         render: @escaping (Parent) -> (State) -> (),
         subsystem: String = "com.wayfair.vsm",
-        loggingEnabled: Bool = false
+        loggingEnabled: Bool = false,
+        signpostsEnabled: Bool = false
     )
     where Parent: AnyObject {
         let observedViewType = String(describing: Parent.self)
@@ -185,7 +189,8 @@ public struct RenderedViewState<State> {
             container: AsyncStateContainer(
                 state: wrappedValue,
                 logger: OSLog(subsystem: subsystem, category: observedViewType),
-                loggingEnabled: loggingEnabled
+                loggingEnabled: loggingEnabled,
+                signpostsEnabled: signpostsEnabled
             ),
             render: anyRender
         )

--- a/Sources/VSM/ViewState.swift
+++ b/Sources/VSM/ViewState.swift
@@ -160,14 +160,15 @@ public struct ViewState<State>: DynamicProperty {
     ///   - initialState: The view state to be managed by the state container.
     ///   - subsystem: The subsystem identifier for logging (defaults to "com.wayfair.vsm").
     ///   - observedViewType: The type of the view being observed, used for logging categorization.
-    ///   - loggingEnabled: When `true`, enables debug logging of state changes to the Console. Defaults to `false`.
-    public init(wrappedValue initialState: State, subsystem: String = "com.wayfair.vsm", observedViewType: Any.Type? = nil, loggingEnabled: Bool = false) {
+    ///   - loggingEnabled: When `true`, enables debug logging of state changes (full description) to the Console. Defaults to `false`.
+    ///   - signpostsEnabled: When `true`, emits Instruments signposts (state name only) for this view's transitions. Opt in per view while profiling; defaults to `false` so no signpost work or state-name reflection occurs otherwise.
+    public init(wrappedValue initialState: State, subsystem: String = "com.wayfair.vsm", observedViewType: Any.Type? = nil, loggingEnabled: Bool = false, signpostsEnabled: Bool = false) {
         var category = "VSM View"
         if let observedViewType {
             category = String(describing: observedViewType)
         }
         
-        self.__container = SwiftUI.State(wrappedValue: AsyncStateContainer(state: initialState, logger: OSLog(subsystem: subsystem, category: category), loggingEnabled: loggingEnabled))
+        self.__container = SwiftUI.State(wrappedValue: AsyncStateContainer(state: initialState, logger: OSLog(subsystem: subsystem, category: category), loggingEnabled: loggingEnabled, signpostsEnabled: signpostsEnabled))
     }
 }
 #endif

--- a/Tests/VSMTests/StateContainerTests.swift
+++ b/Tests/VSMTests/StateContainerTests.swift
@@ -599,6 +599,58 @@ struct StateContainerTests {
         let changes = await container.waitUntilRecordedStateChanges(atLeast: 1, timeout: .seconds(5))
         #expect(changes == [.loaded(.init(count: 1))])
     }
+
+    // MARK: - Signpost Opt-In Tests
+    //
+    // Signposts are off by default; these turn them on to exercise the emission + state-name
+    // code paths and confirm transitions still deliver correctly with signposts enabled. Signpost
+    // output itself is not observable from unit tests, so these assert behavioral equivalence.
+
+    @Test("Signposts enabled: StateSequence transitions still deliver correctly (Mirror-derived name)")
+    @available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, visionOS 2.0, macCatalyst 17.0, *)
+    @MainActor
+    func signpostsEnabledStateSequenceDelivers() async throws {
+        let expectedResult: [MockState] = [
+            .loading,
+            .loaded(.init(count: 2))
+        ]
+        // MockState does not conform to CustomStateNameConvertible, so this exercises the
+        // Mirror-based case-name fallback with signposts on.
+        let container = AsyncStateContainer(state: MockState.initialize(), logger: .disabled, signpostsEnabled: true)
+        container.turnOnRecordingStateHistory()
+
+        guard case let .initialize(initStateModel) = container.state else {
+            throw StateContainerTestError.missingStartState
+        }
+        container.observe(initStateModel.loadSequence())
+
+        let stateChanges = await container.waitUntilRecordedStateChanges(atLeast: 2, timeout: .seconds(5))
+
+        #expect(stateChanges == expectedResult)
+    }
+
+    @Test("Signposts enabled: CustomStateNameConvertible state delivers correctly")
+    @available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, visionOS 2.0, macCatalyst 17.0, *)
+    @MainActor
+    func signpostsEnabledCustomStateNameDelivers() async throws {
+        enum NamedState: Equatable, CustomStateNameConvertible {
+            case first
+            case second(Int)
+            var stateName: String {
+                switch self {
+                case .first: "first"
+                case .second: "second"
+                }
+            }
+        }
+
+        // signpostsEnabled == true means stateName(_:) is invoked, exercising the
+        // `state as? CustomStateNameConvertible` branch.
+        let container = AsyncStateContainer(state: NamedState.first, logger: .disabled, signpostsEnabled: true)
+        container.observe(.second(5))
+
+        #expect(container.state == .second(5))
+    }
 }
 
 // MARK: - Mock Types for Testing State transitions


### PR DESCRIPTION
## Description

Makes VSM's Instruments **signpost emission opt-in per view** and eliminates the reflection cost it previously paid on every state change.

### Background

`AsyncStateContainer` emitted OS signposts (and built their message strings via `String(describing:)`) on **every** state transition, unconditionally. Even with no Instruments session attached, the `StateSequence`/`AsyncSequence` observe paths eagerly computed a full `String(describing:)` of the destination state on each change — a recursive reflection of the entire state payload (associated values, nested collections, etc.). For a state machine that funnels all of a feature's transitions through a single property, that added up during high-frequency flows like pagination and streaming updates.

### What this PR does

- **Adds a per-view `signpostsEnabled` flag** (default `false`) threaded through `ViewState`, `RenderedViewState`, and `AsyncStateContainer`. It is fully independent of the existing `loggingEnabled` flag — you can enable either without the other.
- **Routes every signpost begin/end interval and event through gated helpers** that no-op *and build no message strings* when signposts are disabled. With the default configuration there is now zero signpost work and zero state-name reflection, attached to Instruments or not.
- **Replaces `String(describing:)` in signposts with a cheap `stateName(_:)`** that labels intervals/events with the destination **state name only**. Resolution order: the new `CustomStateNameConvertible` protocol (O(1), author-provided) → the enum case label via `Mirror` (does not materialize the associated value) → `String(describing:)` fallback. The full state description remains available in Console logs via `loggingEnabled`, which is where it belongs.
- **Adds the `CustomStateNameConvertible` public protocol** so state authors can supply an allocation-free, per-case name for signpost output.
- **Documentation:** updates `Reference/Debugging.md` to describe the opt-in signpost behavior and state-name labeling, adds a new `Reference/Profiling.md` guide (choosing an Instruments configuration that reflects production, and why the SwiftUI instrument inflates observable state-mutation cost as a profiler-only observer effect), and links the new article from the DocC catalog.
- **Demo:** opts the Swift 6 Shopping `CartView` into `signpostsEnabled: true` as a usage example.

### Behavior change (non-breaking, but worth calling out)

This is **source-compatible** — the new parameters are defaulted, so existing call sites compile unchanged. However, the **default signpost behavior changes from always-on to off**: views that previously produced signposts in Instruments without any configuration will now need `signpostsEnabled: true`. This is intentional (signposting should be a deliberate, per-view profiling choice) and is documented in the updated Debugging guide.

### Scope note

This addresses VSM's *own* signpost cost. It does not change the separate, profiler-only overhead the SwiftUI instrument adds to any `@Observable` mutation (key-path symbolication for AttributeGraph trace events) — that is inherent to `@Observable` + the SwiftUI template and is documented, with guidance, in the new Profiling article.

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [x] Breaking Change
- [x] Refactor
- [x] Documentation
- [ ] Other (please describe)

> Note: Marked "Breaking Change" only in the *behavioral* sense (signposts now default off). The API is source-compatible — all new parameters are defaulted.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wayfair/vsm-ios/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass