### PR TITLE
Added explicit static and dynamic build targets

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,12 +14,26 @@ let package = Package(
         .visionOS(.v2)
     ],
     products: [
+        // Statically Linkable
         .library(
             name: "LegacyVSM",
+            type: .static,
             targets: ["LegacyVSM"]
         ),
         .library(
             name: "VSM",
+            type: .static,
+            targets: ["VSM"]
+        ),
+        // Dynamically Linkable - use these when you need to access VSM from multiple modules in your repo
+        .library(
+            name: "LegacyVSM-Dynamic",
+            type: .dynamic,
+            targets: ["LegacyVSM"]
+        ),
+        .library(
+            name: "VSM-Dynamic",
+            type: .dynamic,
             targets: ["VSM"]
         ),
     ],


### PR DESCRIPTION
## Description

We found a "bug" in Swift Package Manager where it tries really hard to for dynamic linking. But there are scenarios where you may want to link everything statically in your app. This PR work around that bug by having this package offering "dynamic" and "static" linkable libraries to your app. You have to explicitly set which one you want in your project settings in Xcode, but Swift Package Manager will respect the choice because the product config in our Package manifest forces static or dynamic (depending on your choice).

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [x] Other (please describe) - Build/Package Manifest updates

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wayfair/vsm-ios/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
